### PR TITLE
Add indigeneity checkboxes to student profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ package-lock.json
 /public/css
 /public/images
 /public/js
+docker-compose.yml
+/development

--- a/Modules/Twp/Database/Migrations/2024_02_08_231414_add_indigeneity_types_table.php
+++ b/Modules/Twp/Database/Migrations/2024_02_08_231414_add_indigeneity_types_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(env('DB_DATABASE_TWP'))->create('indigeneity_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('title')->nullable();
+            $table->boolean('active_flag')->default(true);
+            $table->timestamps();
+        });
+
+        // seed the table
+        DB::connection(env('DB_DATABASE_TWP'))->table('indigeneity_types')->insert([
+            [
+                'title' => 'First Nations',
+                'active_flag' => true
+            ],
+            [
+                'title' => 'Metis',
+                'active_flag' => true
+            ],
+            [
+                'title' => 'Inuit',
+                'active_flag' => true
+            ],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(env('DB_DATABASE_TWP'))->dropIfExists('indigeneity_types');
+    }
+};

--- a/Modules/Twp/Database/Migrations/2024_02_08_232612_add_student_indigeneity_table.php
+++ b/Modules/Twp/Database/Migrations/2024_02_08_232612_add_student_indigeneity_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(env('DB_DATABASE_TWP'))->create('indigeneity_student', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('student_id')->constrained('students')->onDelete('cascade');
+            $table->foreignId('indigeneity_id')->constrained('indigeneity_types')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(env('DB_DATABASE_TWP'))->dropIfExists('indigeneity_student');
+    }
+};

--- a/Modules/Twp/Entities/IndigeneityType.php
+++ b/Modules/Twp/Entities/IndigeneityType.php
@@ -2,8 +2,6 @@
 
 namespace Modules\Twp\Entities;
 
-use Illuminate\Database\Eloquent\Model;
-
 class IndigeneityType extends ModuleModel
 {
 

--- a/Modules/Twp/Entities/IndigeneityType.php
+++ b/Modules/Twp/Entities/IndigeneityType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\Twp\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+class IndigeneityType extends ModuleModel
+{
+
+    protected $fillable = ['title', 'is_active'];
+    protected $table = 'indigeneity_types';
+
+    public function students()
+    {
+        return $this->belongsToMany(
+            'Modules\Twp\Entities\Student', 'indigeneity_student','student_id',
+            'indigeneity_id');
+    }
+
+}

--- a/Modules/Twp/Entities/Student.php
+++ b/Modules/Twp/Entities/Student.php
@@ -20,7 +20,7 @@ class Student extends ModuleModel
      */
     protected $fillable = [
         'last_name', 'first_name', 'birth_date', 'email', 'gender', 'pen', 'address', 'citizenship',
-        'bc_resident', 'indigeneity', 'address', 'comment', 'sin', ];
+        'bc_resident', 'address', 'comment', 'sin', ];
 
     public function applications()
     {
@@ -35,6 +35,13 @@ class Student extends ModuleModel
     public function application()
     {
         return $this->hasOne('Modules\Twp\Entities\Application', 'student_id', 'id');
+    }
+
+    public function indigeneity()
+    {
+        return $this->belongsToMany(
+            'Modules\Twp\Entities\IndigeneityType', 'indigeneity_student', 'student_id',
+            'indigeneity_id');
     }
 
     public function getAgeAttribute()

--- a/Modules/Twp/Http/Controllers/IndigeneityTypeController.php
+++ b/Modules/Twp/Http/Controllers/IndigeneityTypeController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Modules\Twp\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Modules\Twp\Entities\IndigeneityType;
+use Illuminate\Support\Facades\Redirect;
+
+class IndigeneityTypeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Inertia\Response::render
+     */
+    public function index(): \Inertia\Response
+    {
+        $this->authorize('create', IndigeneityType::class);
+        $indigeneityTypes = IndigeneityType::get();
+        return Inertia::render('Twp::Maintenance', ['status' => true, 'results' => $indigeneityTypes, 'page' => 'indigeneity']);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\Request  $request
+     * @param  IndigeneityType  $indigeneityType
+     * @return \Illuminate\Http\RedirectResponse::render
+     */
+    public function update(Request $request, IndigeneityType $indigeneity): \Illuminate\Http\RedirectResponse
+    {
+        $this->authorize('update', IndigeneityType::class);
+        $indigeneity->title = $request->title;
+        $indigeneity->active_flag = $request->active_flag;
+        $indigeneity->save();
+
+        return Redirect::route('twp.maintenance.indigeneity.index');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @return \Illuminate\Http\RedirectResponse::render
+     */
+    public function store(Request $request): \Illuminate\Http\RedirectResponse
+    {
+        $this->authorize('create', IndigeneityType::class);
+        IndigeneityType::create($request->all());
+        return Redirect::route('twp.maintenance.indigeneity.index');
+    }
+}

--- a/Modules/Twp/Http/Controllers/IndigeneityTypeController.php
+++ b/Modules/Twp/Http/Controllers/IndigeneityTypeController.php
@@ -16,7 +16,7 @@ class IndigeneityTypeController extends Controller
      */
     public function index(): \Inertia\Response
     {
-        $this->authorize('create', IndigeneityType::class);
+        $this->authorize('viewAny', IndigeneityType::class);
         $indigeneityTypes = IndigeneityType::get();
         return Inertia::render('Twp::Maintenance', ['status' => true, 'results' => $indigeneityTypes, 'page' => 'indigeneity']);
     }

--- a/Modules/Twp/Policies/IndigeneityTypePolicy.php
+++ b/Modules/Twp/Policies/IndigeneityTypePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Modules\Twp\Policies;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Modules\Twp\Entities\IndigeneityType;
+
+class IndigeneityTypePolicy
+{
+    use HandlesAuthorization;
+
+    public function before(User $user, $ability)
+    {
+        return $user->hasRole(Role::SUPER_ADMIN);
+    }
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, IndigeneityType $model): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasRole(Role::TWP_ADMIN) && $user->disabled === false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, IndigeneityType $model): bool
+    {
+        return $user->hasRole(Role::TWP_ADMIN) && $user->disabled === false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, IndigeneityType $model): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, IndigeneityType $model): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, IndigeneityType $model): bool
+    {
+        //
+    }
+}

--- a/Modules/Twp/Policies/IndigeneityTypePolicy.php
+++ b/Modules/Twp/Policies/IndigeneityTypePolicy.php
@@ -21,7 +21,7 @@ class IndigeneityTypePolicy
      */
     public function viewAny(User $user): bool
     {
-        //
+        return $user->hasRole(Role::TWP_ADMIN) && $user->disabled === false;
     }
 
     /**

--- a/Modules/Twp/Resources/assets/js/Components/MaintenanceIndigeneityTypes.vue
+++ b/Modules/Twp/Resources/assets/js/Components/MaintenanceIndigeneityTypes.vue
@@ -1,0 +1,202 @@
+<template>
+    <div class="card">
+        <div class="card-header">
+            <div>Indigeneity Type Maintenance
+                <button type="button" class="btn btn-success btn-sm float-end" data-bs-toggle="modal" data-bs-target="#newIndigeneityTypeModal">New Indigeneity Type</button>
+            </div>
+        </div>
+
+        <div class="card-body">
+            <div v-if="results != null" class="table-responsive pb-3">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th scope="col">Title</th>
+                            <th scope="col">Active</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="(row, i) in results">
+                            <td>
+                                <button @click="editIndigeneityType(i)" type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#editIndigeneityTypeModal">{{ row.title }}</button>
+                            </td>
+                            <td>
+                                <span v-if="row.active_flag" class="badge rounded-pill text-bg-success">True</span>
+                                <span v-else class="badge rounded-pill text-bg-danger">False</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <h1 v-else class="lead">No results</h1>
+        </div>
+
+
+        <div class="modal modal-lg fade" id="newIndigeneityTypeModal" tabindex="-1" aria-labelledby="newIndigeneityTypeModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="newIndigeneityTypeModalLabel">New Indigeneity Type</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <form v-if="newIndigeneityTypeForm != null" @submit.prevent="newIndigeneityType">
+                        <div class="modal-body">
+                            <div class="card-body">
+                                <div class="row g-3">
+
+                                    <div class="col-md-9">
+                                        <BreezeLabel for="newIndigeneityTypeTitle" class="form-label" value="Title *" />
+                                        <BreezeInput type="text" class="form-control" id="newIndigeneityTypeTitle" v-model="newIndigeneityTypeForm.title" />
+                                    </div>
+
+                                    <div class="col-md-3">
+                                        <BreezeLabel for="newIndigeneityTypeActiveFlag" class="form-label" value="Active *" />
+                                        <BreezeSelect class="form-select" id="newIndigeneityTypeActiveFlag" v-model="newIndigeneityTypeForm.active_flag">
+                                            <option value="false">False</option>
+                                            <option value="true">True</option>
+                                        </BreezeSelect>
+                                    </div>
+
+                                </div>
+
+                                <div v-if="newIndigeneityTypeForm.errors != undefined" class="row">
+                                    <div class="col-12">
+                                        <div v-if="newIndigeneityTypeForm.hasErrors == true" class="alert alert-danger mt-3">
+                                            <ul>
+                                                <li v-for="err in newIndigeneityTypeForm.errors"><small>{{ err }}</small></li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="submit" class="btn me-2 btn-outline-success" :disabled="newIndigeneityTypeForm.processing">Submit</button>
+                        </div>
+                        <FormSubmitAlert :form-state="newIndigeneityTypeForm.formState"></FormSubmitAlert>
+                    </form>
+                </div>
+            </div>
+        </div><!-- end new ineligible reason -->
+
+        <div class="modal modal-lg fade" id="editIndigeneityTypeModal" tabindex="-1" aria-labelledby="editIndigeneityTypeModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="editIndigeneityTypeModalLabel">Edit Indigeneity Type</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <form v-if="editIndigeneityTypeForm != null" @submit.prevent="submitEditIndigeneityType">
+                        <div class="modal-body">
+                            <div class="card-body">
+                                <div class="row g-3">
+
+                                    <div class="col-md-9">
+                                        <BreezeLabel for="editIndigeneityTypeTitle" class="form-label" value="Title *" />
+                                        <BreezeInput type="text" class="form-control" id="editIndigeneityTypeTitle" v-model="editIndigeneityTypeForm.title" />
+                                    </div>
+                                    <div class="col-md-3">
+                                        <BreezeLabel for="editIndigeneityTypeActiveFlag" class="form-label" value="Active *" />
+                                        <BreezeSelect class="form-select" id="editIndigeneityTypeActiveFlag" v-model="editIndigeneityTypeForm.active_flag">
+                                            <option value="false">False</option>
+                                            <option value="true">True</option>
+                                        </BreezeSelect>
+                                    </div>
+
+                                </div>
+
+                                <div v-if="editIndigeneityTypeForm.errors != undefined" class="row">
+                                    <div class="col-12">
+                                        <div v-if="editIndigeneityTypeForm.hasErrors == true" class="alert alert-danger mt-3">
+                                            <ul>
+                                                <li v-for="err in editIndigeneityTypeForm.errors"><small>{{ err }}</small></li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="submit" class="btn me-2 btn-outline-success" :disabled="editIndigeneityTypeForm.processing">Submit</button>
+                        </div>
+                        <FormSubmitAlert :form-state="editIndigeneityTypeForm.formState"></FormSubmitAlert>
+                    </form>
+                </div>
+            </div>
+        </div><!-- end edit ineligible reason -->
+
+    </div>
+
+</template>
+<script>
+import {Link, useForm} from '@inertiajs/vue3';
+import BreezeInput from '@/Components/Input.vue';
+import FormSubmitAlert from "@/Components/FormSubmitAlert";
+import BreezeSelect from "@/Components/Select";
+import BreezeLabel from "@/Components/Label";
+
+export default {
+    name: 'MaintenanceIndigeneityTypes',
+    components: {
+        BreezeInput, Link, FormSubmitAlert, BreezeSelect, BreezeLabel
+    },
+    props: {
+        results: Object,
+    },
+    data() {
+        return {
+            newIndigeneityTypeForm: null,
+            newIndigeneityTypeFormData: {
+                formState: true,
+                title: '', active_flag: false,
+            },
+            editIndigeneityTypeForm: null,
+
+        }
+    },
+    methods: {
+        editIndigeneityType: function (index) {
+            this.editIndigeneityTypeForm = useForm(this.results[index]);
+        },
+
+        submitEditIndigeneityType: function () {
+            this.editIndigeneityTypeForm.formState = '';
+            this.editIndigeneityTypeForm.put('/twp/maintenance/indigeneity/' + this.editIndigeneityTypeForm.id, {
+                onSuccess: (response) => {
+                    $("#editIndigeneityTypeModal").modal('hide');
+                    this.editIndigeneityTypeForm.formState = true;
+                },
+                onFailure: () => {
+                },
+                onError: () => {
+                    this.editIndigeneityTypeForm.formState = false;
+                },
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+
+        newIndigeneityType: function ()
+        {
+            this.newIndigeneityTypeForm.formState = '';
+            this.newIndigeneityTypeForm.post('/twp/maintenance/indigeneity', {
+                onSuccess: (response) => {
+                    $("#newIndigeneityTypeModal").modal('hide');
+                    this.newIndigeneityTypeForm.reset(this.newIndigeneityTypeFormData);
+                },
+                onFailure: () => {
+                },
+                onError: () => {
+                    this.newIndigeneityTypeForm.formState = false;
+                },
+                preserveState: true,
+                preserveScroll: true,
+            });
+        },
+    },
+    mounted() {
+        this.newIndigeneityTypeForm = useForm(this.newIndigeneityTypeFormData);
+    }
+}
+
+</script>

--- a/Modules/Twp/Resources/assets/js/Components/MaintenanceMenu.vue
+++ b/Modules/Twp/Resources/assets/js/Components/MaintenanceMenu.vue
@@ -4,6 +4,7 @@
         <Link href="/twp/maintenance/staff" class="list-group-item list-group-item-action" :class="page.split('staff').length > 1 ? 'active' : ''">Staff</Link>
         <Link href="/twp/maintenance/institutions" class="list-group-item list-group-item-action" :class="page.split('institutions').length > 1 ? 'active' : ''">Institutions</Link>
         <Link href="/twp/maintenance/reasons" class="list-group-item list-group-item-action" :class="page.split('reasons').length > 1 ? 'active' : ''">Denial Reasons</Link>
+        <Link href="/twp/maintenance/indigeneity" class="list-group-item list-group-item-action" :class="page.split('indigeneity').length > 1 ? 'active' : ''">Indigeneity Types</Link>
         <Link href="/twp/maintenance/payments" class="list-group-item list-group-item-action" :class="page.split('payments').length > 1 ? 'active' : ''">Payment Types</Link>
         <Link href="/twp/maintenance/reports" class="list-group-item list-group-item-action" :class="page.split('reports').length > 1 ? 'active' : ''">Reports</Link>
     </div>

--- a/Modules/Twp/Resources/assets/js/Components/StudentEditStudentTab.vue
+++ b/Modules/Twp/Resources/assets/js/Components/StudentEditStudentTab.vue
@@ -60,25 +60,25 @@ tr {
                 <BreezeLabel for="inputAddress" class="form-label" value="Address" />
                 <BreezeInput type="text" class="form-control" id="inputAddress" v-model="editForm.address" />
             </div>
-            <div class="col-md-4">
+            <div class="col-md-6">
                 <BreezeLabel for="inputBCResident" class="form-label" value="BC Resident" />
                 <BreezeSelect class="form-select" id="inputBCResident" v-model="editForm.bc_resident">
                     <option value="true">Yes</option>
                     <option value="false">No</option>
                 </BreezeSelect>
             </div>
-            <div class="col-md-4">
-                <BreezeLabel for="inputIndigeneity" class="form-label" value="Indigeneity" />
-                <BreezeSelect class="form-select" id="inputIndigeneity" v-model="editForm.indigeneity">
-                    <option value="No">No</option>
-                    <option value="First Nations">First Nations</option>
-                    <option value="Metis">Metis</option>
-                    <option value="Inuit">Inuit</option>
-                </BreezeSelect>
-            </div>
-            <div class="col-md-4">
+
+            <div class="col-md-6">
                 <BreezeLabel for="inputAge" class="form-label" value="Age" />
                 <BreezeInput type="number" class="form-control bg-light" id="inputAge" v-model="editForm.age" readonly="readonly" disabled />
+            </div>
+
+            <div class="col-md-12">
+                <BreezeLabel for="indigeneity" class="form-label" value="Indigeneity" />
+                <div v-for="type in indigeneity_types" :key="type.id" class="form-check form-check-inline">
+                    <input class="form-check-input" type="checkbox" :id="type.id" :value="type.id" v-model="indigeneity_data" />
+                    <label class="form-check-label" :for="type.id">{{ type.title }}</label>
+                </div>
             </div>
 
             <div class="col-md-12">
@@ -94,7 +94,6 @@ tr {
                     </div>
                 </div>
             </div>
-
 
         </div>
         <div class="card-footer mt-3">
@@ -125,11 +124,14 @@ export default {
         now: String,
         countries: Object,
         provinces: Object,
+        indigeneity_types: Object
+
     },
     data() {
         return {
             noChanges: true,
             editForm: null,
+            indigeneity_data: []
         }
     },
     methods: {
@@ -148,7 +150,7 @@ export default {
                 address: this.editForm.address,
                 citizenship: this.editForm.citizenship,
                 bc_resident: this.editForm.bc_resident,
-                indigeneity: this.editForm.indigeneity,
+                indigeneity: this.indigeneity_data,
                 comment: this.editForm.comment,
             });
 
@@ -166,6 +168,7 @@ export default {
     },
     mounted() {
         this.editForm = this.result;
+        this.indigeneity_data = this.result.indigeneity.map((i) => i.id)
     }
 }
 

--- a/Modules/Twp/Resources/assets/js/Components/StudentEditStudentTab.vue
+++ b/Modules/Twp/Resources/assets/js/Components/StudentEditStudentTab.vue
@@ -125,7 +125,6 @@ export default {
         countries: Object,
         provinces: Object,
         indigeneity_types: Object
-
     },
     data() {
         return {

--- a/Modules/Twp/Resources/assets/js/Pages/Maintenance.vue
+++ b/Modules/Twp/Resources/assets/js/Pages/Maintenance.vue
@@ -30,6 +30,7 @@
                         <MaintenanceStaff v-if="page === 'staff'" :results="results"></MaintenanceStaff>
                         <MaintenanceStaffEdit v-if="page === 'staff-edit'" :results="results"></MaintenanceStaffEdit>
                         <MaintenanceReasons v-if="page === 'reasons'" :results="results"></MaintenanceReasons>
+                        <MaintenanceIndigeneityTypes v-if="page === 'indigeneity'" :results="results"></MaintenanceIndigeneityTypes>
                         <MaintenanceInstitutions v-if="page === 'institutions'" :results="results"></MaintenanceInstitutions>
                         <MaintenancePaymentTypes v-if="page === 'payments'" :results="results"></MaintenancePaymentTypes>
                         <MaintenanceReports v-if="page === 'reports'" :results="results"></MaintenanceReports>
@@ -48,6 +49,7 @@ import MaintenanceStaff from "../Components/MaintenanceStaff";
 import MaintenanceStaffEdit from "../Components/MaintenanceStaffEdit";
 import MaintenanceReasons from "../Components/MaintenanceReasons";
 import MaintenanceInstitutions from "../Components/MaintenanceInstitutions";
+import MaintenanceIndigeneityTypes from "../Components/MaintenanceIndigeneityTypes.vue";
 import MaintenancePaymentTypes from "../Components/MaintenancePaymentTypes";
 import MaintenanceReports from "../Components/MaintenanceReports";
 
@@ -57,6 +59,7 @@ export default {
         MaintenanceReports,
         MaintenancePaymentTypes,
         MaintenanceInstitutions,
+        MaintenanceIndigeneityTypes,
         MaintenanceReasons,
         MaintenanceMenu,
         BreezeAuthenticatedLayout, Head, Link, MaintenanceStaff, MaintenanceStaffEdit

--- a/Modules/Twp/Resources/assets/js/Pages/StudentEdit.vue
+++ b/Modules/Twp/Resources/assets/js/Pages/StudentEdit.vue
@@ -309,7 +309,6 @@ export default {
         provinces: Object,
         p_types: Object,
         indigeneity_types: Object,
-
         schools: Object,
         batches: Object,
         ineligibles: Object,

--- a/Modules/Twp/Resources/assets/js/Pages/StudentEdit.vue
+++ b/Modules/Twp/Resources/assets/js/Pages/StudentEdit.vue
@@ -24,7 +24,7 @@
                                     </Link> Student Info
                                 </div>
                                 <div v-if="editForm != null" class="card-body">
-                                    <StudentEditStudentTab :result="editForm"></StudentEditStudentTab>
+                                    <StudentEditStudentTab :result="editForm" :indigeneity_types="indigeneity_types"></StudentEditStudentTab>
                                 </div>
                             </div>
                             <div class="card mb-2">
@@ -308,6 +308,7 @@ export default {
         reasons: Object,
         provinces: Object,
         p_types: Object,
+        indigeneity_types: Object,
 
         schools: Object,
         batches: Object,

--- a/Modules/Twp/Resources/assets/js/Pages/Students.vue
+++ b/Modules/Twp/Resources/assets/js/Pages/Students.vue
@@ -108,29 +108,28 @@
                                         <BreezeLabel for="inputAddress" class="form-label" value="Address" />
                                         <BreezeInput type="text" class="form-control" id="inputAddress" v-model="newStudentForm.address" />
                                     </div>
-                                    <div class="col-md-4">
+                                    <div class="col-md-6">
                                         <BreezeLabel for="inputBCResident" class="form-label" value="BC Resident" />
                                         <BreezeSelect class="form-select" id="inputBCResident" v-model="newStudentForm.bc_resident">
                                             <option value="true">Yes</option>
                                             <option value="false">No</option>
                                         </BreezeSelect>
                                     </div>
-                                    <div class="col-md-4">
-                                        <BreezeLabel for="inputIndigeneity" class="form-label" value="Indigeneity" />
-                                        <BreezeSelect class="form-select" id="inputIndigeneity" v-model="newStudentForm.indigeneity">
-                                            <option value="No">No</option>
-                                            <option value="First Nations">First Nations</option>
-                                            <option value="Metis">Metis</option>
-                                            <option value="Inuit">Inuit</option>
-                                        </BreezeSelect>
-                                    </div>
-                                    <div class="col-md-4">
+
+                                    <div class="col-md-6">
                                         <BreezeLabel for="inputGender" class="form-label" value="Gender" />
                                         <BreezeSelect class="form-select" id="inputGender" v-model="newStudentForm.gender">
                                             <option value="M">Male</option>
                                             <option value="F">Female</option>
                                             <option value="O">Other</option>
                                         </BreezeSelect>
+                                    </div>
+                                    <div class="col-md-12">
+                                        <BreezeLabel for="indigeneity" class="form-label" value="Indigeneity" />
+                                        <div v-for="type in indigeneity_types" :key="type.id" class="form-check form-check-inline">
+                                            <input class="form-check-input" type="checkbox" :id="type.id" :value="type.id" v-model="newStudentForm.indigeneity" />
+                                            <label class="form-check-label" :for="type.id">{{ type.title }}</label>
+                                        </div>
                                     </div>
                                     <div class="col-md-12">
                                         <BreezeLabel for="inputComment" class="form-label" value="Comment" />
@@ -181,6 +180,7 @@ export default {
         countries: Object,
         provinces: Object,
         schools: Object,
+        indigeneity_types: Object
     },
     data() {
         return {
@@ -200,7 +200,7 @@ export default {
                 institution_student_number: '',
                 citizenship: '',
                 bc_resident: '',
-                indigeneity: '',
+                indigeneity: [],
                 comment: '',
 
             },

--- a/Modules/Twp/Routes/web.php
+++ b/Modules/Twp/Routes/web.php
@@ -37,6 +37,11 @@ Route::prefix('twp')->group(function () {
                     Route::get('/staff', 'MaintenanceController@staffList')->name('staff.list');
                     Route::get('/staff/{user}', 'MaintenanceController@staffShow')->name('staff.show');
                     Route::post('/staff/{user}', 'MaintenanceController@staffEdit')->name('staff.edit');
+
+                    Route::get('/indigeneity', 'IndigeneityTypeController@index')->name('indigeneity.index');
+                    Route::post('/indigeneity', 'IndigeneityTypeController@store')->name('indigeneity.store');
+                    Route::put('/indigeneity/{indigeneity}', 'IndigeneityTypeController@update')->name('indigeneity.update');
+
                     Route::get('/institutions', 'MaintenanceController@institutionList')->name('institutions.list');
                     Route::post('/institutions', 'MaintenanceController@institutionStore')->name('institutions.store');
                     Route::put('/institutions/{institution}', 'MaintenanceController@institutionUpdate')->name('institutions.update');


### PR DESCRIPTION
Create database migrations for a new "indigeneity_types" and "student_indigeneity" tables

Admin users can create and modify indigeneity types on the maintenance page:
![Screenshot (87)](https://github.com/bcgov/rvs/assets/25233684/c987bc79-849d-4e79-aa4b-b483bbc81ade)


When adding or editing a student's profile, users have the ability to select zero, one or more indigeneity checkboxes as appropriate:
![Screenshot (88)](https://github.com/bcgov/rvs/assets/25233684/0b54b640-782e-4c6f-87fc-d6fe32da404d)

