### PR TITLE
Sabc 4719 - NEB - Modernize custom codebase following PHP 8.3 recommendations and code standards

### DIFF
--- a/Modules/Neb/Database/Seeders/TablesSeeders/NebFyBudgetsTableSeeder.php
+++ b/Modules/Neb/Database/Seeders/TablesSeeders/NebFyBudgetsTableSeeder.php
@@ -14,7 +14,7 @@ class NebFyBudgetsTableSeeder extends Seeder {
         $currentYear = date('Y');
 
         for ($i = 0; $i < 5; $i++) {
-            $fiscalYear = ($currentYear + $i) . '-' . substr(($currentYear + $i + 1), -2);
+            $fiscalYear = ($currentYear + $i) . '-' . substr((string)($currentYear + $i + 1), -2);
 
             DB::connection('neb')->table('fy_budgets')->updateOrInsert(
                 ['fiscal_year' => $fiscalYear],

--- a/Modules/Neb/Database/Seeders/TablesSeeders/NebPotentialsTableSeeder.php
+++ b/Modules/Neb/Database/Seeders/TablesSeeders/NebPotentialsTableSeeder.php
@@ -34,9 +34,13 @@ class NebPotentialsTableSeeder extends Seeder
                     'weekly_unmet_need' => $faker->randomFloat(2, 0, 500),
                     'program_year' => $faker->numberBetween(1, 4),
                     'street_address1' => $faker->streetAddress,
-                    'street_address2' => $faker->optional()->secondaryAddress,
+                    'street_address2' => $faker->optional()->streetAddress,
                     'city' => $faker->city,
-                    'province' => $faker->state,
+                    'province' => $faker->randomElement([
+                        'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick',
+                        'Newfoundland and Labrador', 'Nova Scotia', 'Ontario',
+                        'Prince Edward Island', 'Quebec', 'Saskatchewan'
+                    ]),
                     'gender' => $faker->randomElement(['M', 'F', 'O']),
                     'phone_number' => $faker->numerify('##########'),
                     'study_start_date' => $studyStartDate,

--- a/Modules/Neb/Database/Seeders/TablesSeeders/NebStudentsTableSeeder.php
+++ b/Modules/Neb/Database/Seeders/TablesSeeders/NebStudentsTableSeeder.php
@@ -32,10 +32,14 @@ class NebStudentsTableSeeder extends Seeder
                     'citizenship' => substr($faker->country, 0, 20),
                     'marital_status' => $faker->randomElement(['Single', 'Married', 'Divorced', 'Widowed']),
                     'address1' => $faker->streetAddress,
-                    'address2' => $faker->optional()->secondaryAddress,
+                    'address2' => $faker->optional()->streetAddress,
                     'city' => substr($faker->city, 0, 40),
                     'postal_code' => substr($faker->postcode, 0, 7),
-                    'province' => substr($faker->state, 0, 40),
+                    'province' => $faker->randomElement([
+                        'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick',
+                        'Newfoundland and Labrador', 'Nova Scotia', 'Ontario',
+                        'Prince Edward Island', 'Quebec', 'Saskatchewan'
+                    ]),
                     'country' => substr($faker->country, 0, 40),
                     'phone_number' => substr($faker->phoneNumber, 0, 10),
                     'email' => $faker->safeEmail,

--- a/Modules/Neb/Entities/Application.php
+++ b/Modules/Neb/Entities/Application.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Application extends ModuleModel
 {
@@ -17,12 +18,17 @@ class Application extends ModuleModel
         'student_id', 'sin', 'application_number', 'complete', 'eligible', 'award_status', 'rank', 'total_score', 'receive_date',
         'effective_date', 'process_date', 'comment', 'program_code', 'bursary_period_id', ];
 
-    public function student()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Student, Application>
+     */
+    public function student(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Student', 'sin', 'sin');
     }
 
-    public function bursaryPeriod()
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<BursaryPeriod, Application>
+     */
+    public function bursaryPeriod(): BelongsTo
     {
         return $this->belongsTo('Modules\Neb\Entities\BursaryPeriod', 'bursary_period_id', 'id');
     }

--- a/Modules/Neb/Entities/BursaryPeriod.php
+++ b/Modules/Neb/Entities/BursaryPeriod.php
@@ -4,6 +4,23 @@ namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @property int $id
+ * @property string|null $bursary_period_start_date
+ * @property string|null $bursary_period_end_date
+ * @property bool $awarded Indicates if awards are distributed for period (yes or no)
+ * @property float|null $default_award The default amount of award for period
+ * @property float|null $period_budget Total budget amount for period
+ * @property int|null $rn_budget Number between 1 and 100; portion of budget to allocate to RN programs
+ * @property int|null $public_sector_budget Number between 1 and 100; portion of budget to allocate to public sector programs
+ * @property string|null $budget_allocation_type Method of allocating budget; either by sector (private/public), nurse type (LPN/RN), or none
+ * @property string|null $created_at
+ * @property string|null $updated_at
+ *
+ * // Accessors
+ * @property string $bpsd Formatted start date (y-m-d)
+ * @property string $bped Formatted end date (y-m-d)
+ */
 class BursaryPeriod extends ModuleModel
 {
     use HasFactory;

--- a/Modules/Neb/Entities/BursaryPeriod.php
+++ b/Modules/Neb/Entities/BursaryPeriod.php
@@ -26,13 +26,17 @@ class BursaryPeriod extends ModuleModel
         'budget_allocation_type',
     ];
 
-    public function getBpsdAttribute()
-    {
+    /**
+     * @return string
+     */
+    public function getBpsdAttribute(): string {
         return date('y-m-d', strtotime($this->bursary_period_start_date));
     }
 
-    public function getBpedAttribute()
-    {
+    /**
+     * @return string
+     */
+    public function getBpedAttribute(): string {
         return date('y-m-d', strtotime($this->bursary_period_end_date));
     }
 }

--- a/Modules/Neb/Entities/ElPotential.php
+++ b/Modules/Neb/Entities/ElPotential.php
@@ -6,6 +6,63 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @property int $id
+ * @property int|null $application_number
+ * @property int|null $sin
+ * @property string|null $postal_code
+ * @property string|null $birth_date
+ * @property string|null $first_name
+ * @property string|null $middle_name
+ * @property string|null $last_name
+ * @property float|null $assessed_need_amount
+ * @property float|null $total_unmet_need
+ * @property int|null $weeks_of_study
+ * @property float|null $weekly_unmet_need
+ * @property string|null $program_year
+ * @property string|null $street_address1
+ * @property string|null $street_address2
+ * @property string|null $city
+ * @property string|null $province
+ * @property string|null $gender
+ * @property string|null $phone_number
+ * @property string|null $study_start_date
+ * @property string|null $study_end_date
+ * @property string|null $institution_name
+ * @property string|null $program_code
+ * @property string|null $inst_code
+ * @property string|null $area_of_study
+ * @property string|null $degree_level
+ * @property string|null $receive_date
+ * @property int|null $bursary_period_id
+ * @property bool|null $month_overlap
+ * @property int|null $num_day_overlap
+ * @property bool|null $valid_institution
+ * @property bool|null $restriction
+ * @property bool|null $awarded_in_prior_year
+ * @property bool|null $withdrawal
+ * @property string|null $nurse_type
+ * @property string|null $sector
+ * @property string|null $eligibility
+ * @property string|null $neb_ineligible_reason
+ * @property int|null $rank_by_unmet_need
+ * @property int|null $rank_by_nurse_type
+ * @property int|null $rank_by_sector
+ * @property string|null $award_or_deny
+ * @property string|null $neb_deny_reason
+ * @property float|null $award_amount
+ * @property int|null $sfas_award_id
+ * @property int|null $supplier_no
+ * @property string|null $created_by
+ * @property bool $finalized
+ * @property string|null $created_at
+ * @property string|null $updated_at
+ * @property string|null $deleted_at
+ *
+ * // Relations
+ * @property Student|null $student
+ * @property BursaryPeriod|null $bursaryPeriod
+ */
 class ElPotential extends ModuleModel
 {
     use HasFactory;

--- a/Modules/Neb/Entities/ElPotential.php
+++ b/Modules/Neb/Entities/ElPotential.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ElPotential extends ModuleModel
@@ -26,12 +27,17 @@ class ElPotential extends ModuleModel
         'award_amount', 'sfas_award_id', 'supplier_no', 'created_by', 'finalized',
     ];
 
-    public function student()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Student, ElPotential>
+     */
+    public function student(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Student', 'sin', 'sin');
     }
 
-    public function bursaryPeriod()
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<BursaryPeriod, ElPotential>
+     */
+    public function bursaryPeriod(): BelongsTo
     {
         return $this->belongsTo('Modules\Neb\Entities\BursaryPeriod', 'bursary_period_id', 'id');
     }

--- a/Modules/Neb/Entities/ElPotentialRestriction.php
+++ b/Modules/Neb/Entities/ElPotentialRestriction.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ElPotentialRestriction extends ModuleModel
 {
@@ -17,12 +18,17 @@ class ElPotentialRestriction extends ModuleModel
         'sin', 'bursary_period_id',
     ];
 
-    public function student()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Student, ElPotentialRestriction>
+     */
+    public function student(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Student', 'sin', 'sin');
     }
 
-    public function bursaryPeriod()
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<BursaryPeriod, ElPotentialRestriction>
+     */
+    public function bursaryPeriod(): BelongsTo
     {
         return $this->belongsTo('Modules\Neb\Entities\BursaryPeriod', 'bursary_period_id', 'id');
     }

--- a/Modules/Neb/Entities/ElPotentialRestrictionDetail.php
+++ b/Modules/Neb/Entities/ElPotentialRestrictionDetail.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ElPotentialRestrictionDetail extends ModuleModel
 {
@@ -17,18 +18,25 @@ class ElPotentialRestrictionDetail extends ModuleModel
         'sin', 'bursary_period_id', 'restriction_code', 'restriction_description', 'applied_date',
     ];
 
-    public function student()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Student, ElPotentialRestrictionDetail>
+     */
+    public function student(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Student', 'sin', 'sin');
     }
 
-    public function bursaryPeriod()
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<BursaryPeriod, ElPotentialRestrictionDetail>
+     */
+    public function bursaryPeriod(): BelongsTo
     {
         return $this->belongsTo('Modules\Neb\Entities\BursaryPeriod', 'bursary_period_id', 'id');
     }
 
-    public function restriction()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Restriction, ElPotentialRestrictionDetail>
+     */
+    public function restriction(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Restriction', 'restriction_code', 'restriction_code');
     }
 }

--- a/Modules/Neb/Entities/ModuleModel.php
+++ b/Modules/Neb/Entities/ModuleModel.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class ModuleModel extends Model
 {
+
+    /**
+     * @param array $attributes<string, mixed>
+     */
     public function __construct(array $attributes = [])
     {
         parent::__construct($attributes);

--- a/Modules/Neb/Entities/ModuleModel.php
+++ b/Modules/Neb/Entities/ModuleModel.php
@@ -8,7 +8,7 @@ class ModuleModel extends Model
 {
 
     /**
-     * @param array $attributes<string, mixed>
+     * @param array<string, mixed> $attributes
      */
     public function __construct(array $attributes = [])
     {

--- a/Modules/Neb/Entities/Neb.php
+++ b/Modules/Neb/Entities/Neb.php
@@ -5,6 +5,36 @@ namespace Modules\Neb\Entities;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int $id
+ * @property int|null $application_id
+ * @property int|null $bursary_period_id
+ * @property string|null $program_code
+ * @property string|null $inst_code
+ * @property string|null $study_start_date
+ * @property string|null $study_end_date
+ * @property string|null $sfas_program_code
+ * @property float|null $award_amount
+ * @property string|null $declined_removed_reason Reason why application was declined or removed
+ * @property int|null $sfas_award_id Random id produced by legacy NEB system
+ * @property float|null $unmet_need
+ * @property int|null $weeks_of_study
+ * @property float|null $weekly_unmet_need
+ * @property float|null $assessed_need_amount
+ * @property string|null $nurse_type LPN or RN
+ * @property string|null $sector public or private
+ * @property bool $valid_institution Valid institutions are open, designated, BC institutions
+ * @property bool $restriction Yes if borrower has one or more restrictions (including bankruptcies)
+ * @property bool $awarded_in_prior_year Yes if borrower received grant in prior three bursary periods
+ * @property bool $withdrawal Yes if borrower withdrew within bursary period
+ * @property string|null $neb_ineligible_reason Reason why borrower was ineligible for grant
+ * @property string|null $created_at
+ * @property string|null $updated_at
+ *
+ * // Relations
+ * @property Application|null $application
+ * @property BursaryPeriod|null $bursaryPeriod
+ */
 class Neb extends ModuleModel
 {
     use HasFactory;

--- a/Modules/Neb/Entities/Neb.php
+++ b/Modules/Neb/Entities/Neb.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Neb extends ModuleModel
 {
@@ -20,11 +21,16 @@ class Neb extends ModuleModel
         'awarded_in_prior_year', 'withdrawal', 'neb_ineligible_reason',
     ];
 
-    public function application()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Application, Neb>
+     */
+    public function application(): BelongsTo {
         return $this->belongsTo('Modules\Neb\Entities\Application', 'application_id', 'application_id');
     }
 
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<BursaryPeriod, Neb>
+     */
     public function bursaryPeriod()
     {
         return $this->belongsTo('Modules\Neb\Entities\BursaryPeriod', 'bursary_period_id', 'id');

--- a/Modules/Neb/Entities/Student.php
+++ b/Modules/Neb/Entities/Student.php
@@ -3,6 +3,7 @@
 namespace Modules\Neb\Entities;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Student extends ModuleModel
@@ -20,8 +21,10 @@ class Student extends ModuleModel
         'citizenship', 'old_last_name', 'old_middle_name', 'old_first_name', 'last_name', 'middle_name', 'first_name',
         'gender', 'pen', 'date_of_birth', 'sin', ];
 
-    public function applications()
-    {
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Application>
+     */
+    public function applications(): HasMany {
         return $this->hasMany('Modules\Neb\Entities\Application', 'sin', 'sin');
     }
 }

--- a/Modules/Neb/Http/Controllers/BursaryPeriodController.php
+++ b/Modules/Neb/Http/Controllers/BursaryPeriodController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Response as FacadeResponse;
 use Modules\Neb\Entities\Application;
 use Modules\Neb\Entities\BursaryPeriod;
 use Modules\Neb\Entities\Neb;
@@ -31,7 +32,7 @@ class BursaryPeriodController extends Controller
     public function tobeAwarded(): JsonResponse {
         $bp = BursaryPeriod::where('awarded', false)->get();
 
-        return \Illuminate\Support\Facades\Response::json([
+        return FacadeResponse::json([
             'status' => 'success',
             'bp' => $bp,
         ]);
@@ -41,9 +42,9 @@ class BursaryPeriodController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return response.json
+     * @return \Illuminate\Http\JsonResponse.json
      */
-    public function fetch(Request $request): Response {
+    public function fetch(Request $request): JsonResponse {
         if ($request->id) {
             $bp = BursaryPeriod::find($request->id);
 
@@ -56,7 +57,7 @@ class BursaryPeriodController extends Controller
 
         $bursaryPeriods = BursaryPeriod::orderBy('bursary_period_start_date', 'desc')->get();
 
-        return Response::json([
+        return FacadeResponse::json([
             'page' => 'bursary-periods',
             'bp' => $bursaryPeriods,
         ]);

--- a/Modules/Neb/Http/Controllers/BursaryPeriodController.php
+++ b/Modules/Neb/Http/Controllers/BursaryPeriodController.php
@@ -2,15 +2,17 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
+use Inertia\Response;
 use Modules\Neb\Entities\Application;
 use Modules\Neb\Entities\BursaryPeriod;
 use Modules\Neb\Entities\Neb;
 use Modules\Neb\Http\Requests\BursaryPeriodEditRequest;
 use Modules\Neb\Http\Requests\BursaryPeriodStoreRequest;
-use Response;
 
 class BursaryPeriodController extends Controller
 {
@@ -19,16 +21,17 @@ class BursaryPeriodController extends Controller
      *
      * @return \Inertia\Response
      */
-    public function index()
-    {
+    public function index(): Response {
         return Inertia::render('Neb::BursaryPeriods', ['page' => 'bursary-periods']);
     }
 
-    public function tobeAwarded()
-    {
+    /**
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function tobeAwarded(): JsonResponse {
         $bp = BursaryPeriod::where('awarded', false)->get();
 
-        return Response::json([
+        return \Illuminate\Support\Facades\Response::json([
             'status' => 'success',
             'bp' => $bp,
         ]);
@@ -40,8 +43,7 @@ class BursaryPeriodController extends Controller
      *
      * @return response.json
      */
-    public function fetch(Request $request)
-    {
+    public function fetch(Request $request): Response {
         if ($request->id) {
             $bp = BursaryPeriod::find($request->id);
 
@@ -63,10 +65,11 @@ class BursaryPeriodController extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param \Modules\Neb\Http\Requests\BursaryPeriodStoreRequest $request
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(BursaryPeriodStoreRequest $request)
-    {
+    public function store(BursaryPeriodStoreRequest $request): RedirectResponse {
         $bursaryPeriod = BursaryPeriod::create($request->validated());
 
         return Redirect::route('neb.bursary-periods.show', [$bursaryPeriod->id]);
@@ -75,10 +78,12 @@ class BursaryPeriodController extends Controller
     /**
      * Update the specified resource in storage.
      *
+     * @param \Modules\Neb\Http\Requests\BursaryPeriodEditRequest $request
+     * @param \Modules\Neb\Entities\BursaryPeriod $bursaryPeriod
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(BursaryPeriodEditRequest $request, BursaryPeriod $bursaryPeriod)
-    {
+    public function update(BursaryPeriodEditRequest $request, BursaryPeriod $bursaryPeriod): RedirectResponse {
         $bursaryPeriod::where('id', $bursaryPeriod->id)->update($request->validated());
 
         return Redirect::route('neb.bursary-periods.show', [$bursaryPeriod->id]);
@@ -89,8 +94,7 @@ class BursaryPeriodController extends Controller
      *
      * @return \Illuminate\Http\RedirectResponse.redirect
      */
-    public function delete(Request $request)
-    {
+    public function delete(Request $request): RedirectResponse {
         $bP = BursaryPeriod::where('id', $request->input('id'))->first();
         if ($bP != null) {
             //remove all records entered for the same bursary period from previous runs

--- a/Modules/Neb/Http/Controllers/BursaryPeriodController.php
+++ b/Modules/Neb/Http/Controllers/BursaryPeriodController.php
@@ -48,7 +48,7 @@ class BursaryPeriodController extends Controller
         if ($request->id) {
             $bp = BursaryPeriod::find($request->id);
 
-            return Response::json([
+            return FacadeResponse::json([
                 'id' => $request->id,
                 'page' => 'bursary-periods',
                 'bp' => $bp,

--- a/Modules/Neb/Http/Controllers/MaintenanceController.php
+++ b/Modules/Neb/Http/Controllers/MaintenanceController.php
@@ -11,10 +11,13 @@ use Inertia\Inertia;
 
 class MaintenanceController extends Controller
 {
+
     /**
      * Display a listing of the resource.
      *
-     * @return \Inertia\Response::render
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Inertia\Response
      */
     public function staffList(Request $request): \Inertia\Response
     {
@@ -37,7 +40,10 @@ class MaintenanceController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Inertia\Response::render
+     * @param \Illuminate\Http\Request $request
+     * @param \App\Models\User $user
+     *
+     * @return \Inertia\Response
      */
     public function staffShow(Request $request, User $user): \Inertia\Response
     {
@@ -53,7 +59,11 @@ class MaintenanceController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Http\RedirectResponse::render
+     * @param \App\Http\Requests\StaffEditRequest $request
+     * @param \App\Models\User $user
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function staffEdit(StaffEditRequest $request, User $user): \Illuminate\Http\RedirectResponse
     {

--- a/Modules/Neb/Http/Controllers/NebController.php
+++ b/Modules/Neb/Http/Controllers/NebController.php
@@ -2,11 +2,11 @@
 
 namespace Modules\Neb\Http\Controllers;
 
-use Auth;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
@@ -29,28 +29,28 @@ class NebController extends Controller
 {
 
     /**
-     * @var
+     * @var string
      */
     public $programCodesString;
 
     /**
-     * @var
+     * @var string
      */
     public $formattedBpsd;
 
     /**
-     * @var
+     * @var string
      */
     public $formattedBped;
 
     /**
      * @param \Illuminate\Http\Request $request
-     * @param $type
-     * @param $id
+     * @param string $type
+     * @param int $id
      *
      * @return \Symfony\Component\HttpFoundation\StreamedResponse|Response|null
      */
-    public function exportNeb(Request $request, $type, $id): StreamedResponse|Response|null {
+    public function exportNeb(Request $request, string $type, int $id): StreamedResponse|Response|null {
         $bursaryPeriod = BursaryPeriod::find($id);
         if ($bursaryPeriod == null) {
             return null;
@@ -62,6 +62,7 @@ class NebController extends Controller
                 'in' => 'ineligible',
                 'aw' => 'awarded',
                 'aw_txt' => 'awarded_text',
+                default => throw new \InvalidArgumentException("Invalid export type: $type")
             };
 
             //default to exporting awarded
@@ -837,12 +838,12 @@ class NebController extends Controller
     }
 
     /**
-     * @param $record
-     * @param $bp
+     * @param ElPotential $record
+     * @param BursaryPeriod $bp
      *
      * @return string
      */
-    public function awardedTextLine($record, $bp): string {
+    public function awardedTextLine(ElPotential $record, BursaryPeriod $bp): string {
         $line = 'SP04';
         $line .= $this->padStringWithSpaces(date('Ymd', strtotime($bp->bursary_period_start_date)), 8);
         $line .= $this->padStringWithSpaces(date('Ymd', strtotime($bp->bursary_period_end_date)), 8);
@@ -883,11 +884,11 @@ class NebController extends Controller
     }
 
     /**
-     * @param $record
+     * @param ElPotential $record
      *
      * @return string
      */
-    private function prepareCsvLine($record): string {
+    private function prepareCsvLine(ElPotential $record): string {
         $csvValues = [
             $record->application_number,
             $record->sin,
@@ -939,13 +940,13 @@ class NebController extends Controller
     }
 
     /**
-     * @param $inputString
-     * @param $desiredLength
-     * @param $preFixWithZero
+     * @param string|float|int|null $inputString
+     * @param int $desiredLength
+     * @param bool $preFixWithZero
      *
      * @return string
      */
-    private function padStringWithSpaces($inputString, $desiredLength, $preFixWithZero = false): string {
+    private function padStringWithSpaces(string|float|int|null $inputString, int $desiredLength, bool $preFixWithZero = false): string {
         if ($inputString === null) {
             $inputString = '';
         }

--- a/Modules/Neb/Http/Controllers/NebController.php
+++ b/Modules/Neb/Http/Controllers/NebController.php
@@ -4,11 +4,14 @@ namespace Modules\Neb\Http\Controllers;
 
 use Auth;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Response;
+use Illuminate\Http\Response as HttpResponse;
 use Inertia\Inertia;
 use Modules\Neb\Entities\Application;
 use Modules\Neb\Entities\BursaryPeriod;
@@ -20,17 +23,34 @@ use Modules\Neb\Entities\Neb;
 use Modules\Neb\Entities\Restriction;
 use Modules\Neb\Entities\SfasProgram;
 use Modules\Neb\Entities\Student;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class NebController extends Controller
 {
+
+    /**
+     * @var
+     */
     public $programCodesString;
 
+    /**
+     * @var
+     */
     public $formattedBpsd;
 
+    /**
+     * @var
+     */
     public $formattedBped;
 
-    public function exportNeb(Request $request, $type, $id)
-    {
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param $type
+     * @param $id
+     *
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse|Response|null
+     */
+    public function exportNeb(Request $request, $type, $id): StreamedResponse|Response|null {
         $bursaryPeriod = BursaryPeriod::find($id);
         if ($bursaryPeriod == null) {
             return null;
@@ -96,12 +116,16 @@ class NebController extends Controller
         } catch (\Exception $exception) {
             Log::error('Error generating CSV for download: '.$exception);
 
-            return Response::make('Internal server error.', 500, []);
+            return HttpResponse::make('Internal server error.', 500, []);
         }
     }
 
-    public function fetchNeb(Request $request)
-    {
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Inertia\Response|null
+     */
+    public function fetchNeb(Request $request): ?\Inertia\Response {
         $bpId = $request->id ?? $request->input('id');
         $sortBy = $request->input('sort_by') ?? 'id';
         $sortDir = $request->input('sort_dir') ?? 'asc';
@@ -138,7 +162,12 @@ class NebController extends Controller
 
     // FINALIZE FUNCTIONS START HERE
 
-    public function finalizeNeb(Request $request)
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Inertia\Response|null
+     */
+    public function finalizeNeb(Request $request): RedirectResponse|\Inertia\Response|null
     {
         $bursaryPeriod = BursaryPeriod::find($request->input('bursary_period_id'));
         if ($bursaryPeriod == null) {
@@ -173,7 +202,12 @@ class NebController extends Controller
         return Redirect::route('neb.bursary-periods.show', [$bursaryPeriod->id]);
     }
 
-    private function processStudents(BursaryPeriod $bP)
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    private function processStudents(BursaryPeriod $bP): true
     {
         $students = ElPotential::where('bursary_period_id', $bP->id)->get();
         foreach ($students as $student) {
@@ -195,8 +229,12 @@ class NebController extends Controller
         return true;
     }
 
-    private function createApplications(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    private function createApplications(BursaryPeriod $bP): true {
         $now = Carbon::now();
         $potentials = ElPotential::where('bursary_period_id', $bP->id)->get();
 
@@ -240,8 +278,12 @@ class NebController extends Controller
         return true;
     }
 
-    private function cleanup(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    private function cleanup(BursaryPeriod $bP): true {
 
         ElPotential::where('bursary_period_id', $bP->id)->update(['finalized' => true]);
         $bP->awarded = true;
@@ -250,8 +292,12 @@ class NebController extends Controller
         return true;
     }
 
-    public function processNeb(Request $request)
-    {
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Inertia\Response|null
+     */
+    public function processNeb(Request $request): RedirectResponse|\Inertia\Response|null {
         ini_set('memory_limit', '512M');
 
         $bursaryPeriod = BursaryPeriod::find($request->input('bursary_period_id'));
@@ -321,10 +367,11 @@ class NebController extends Controller
      *
      * @input bp: BursaryPeriod object
      *
-     * @return \Illuminate\Database\Eloquent\Collection.json
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return null|\Illuminate\Database\Eloquent\Collection<int, ElPotential>
      */
-    private function nebElPotentials(BursaryPeriod $bP)
-    {
+    private function nebElPotentials(BursaryPeriod $bP): null|Collection {
         if ($bP == null) {
             return null;
         }
@@ -413,8 +460,12 @@ class NebController extends Controller
         return ElPotential::all();
     }
 
-    private function monthOverlap(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return array<string>|Collection<int, ElPotential>
+     */
+    private function monthOverlap(BursaryPeriod $bP): array|Collection {
         \Log::info('processing: monthOverlap');
         $potentials = ElPotential::where('bursary_period_id', $bP->id)->get();
 
@@ -454,8 +505,12 @@ class NebController extends Controller
         return $potentials;
     }
 
-    private function validInstitution(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return array<ElPotential>
+     */
+    private function validInstitution(BursaryPeriod $bP): array {
         \Log::info('processing: validInstitution');
         $envQuery1 = env('VALIDATE_INSTITUTION_QUERY1');
         $strSQL3 = DB::connection('oracle')->select($envQuery1);
@@ -474,8 +529,12 @@ class NebController extends Controller
         return $strSQL3;
     }
 
-    private function restriction(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return array<ElPotential>
+     */
+    private function restriction(BursaryPeriod $bP): array {
         $restrictionCodes = Restriction::select('restriction_code')->get();
         $restrictionString = $restrictionCodes->pluck('restriction_code')->map(function ($row) {
             return "'".$row."'";
@@ -528,8 +587,12 @@ class NebController extends Controller
         return $strSQL2;
     }
 
-    private function awardedInPriorYear(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return mixed
+     */
+    private function awardedInPriorYear(BursaryPeriod $bP): mixed {
         $bpLastTwo = BursaryPeriod::select('id')->whereNot('id', $bP->id)->orderBy('id', 'desc')->limit(2)->get();
         $awardedApps = Application::distinct('applications.sin')
             ->join('nebs', 'nebs.application_id', '=', 'applications.id')
@@ -541,8 +604,12 @@ class NebController extends Controller
         return ElPotential::where('bursary_period_id', $bP->id)->whereIn('sin', $awardedApps)->update(['awarded_in_prior_year' => true]);
     }
 
-    private function withdrawal(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return mixed
+     */
+    private function withdrawal(BursaryPeriod $bP): mixed {
         $envQuery = env('WITHDRAWALS_QUERY1');
         $qry = sprintf($envQuery, $this->programCodesString, $this->formattedBpsd, $this->formattedBped, $this->formattedBpsd, $this->formattedBped, $this->formattedBpsd, $this->formattedBped);
 
@@ -553,8 +620,12 @@ class NebController extends Controller
             ->whereIn('sin', $restrictedSinArray)->update(['withdrawal' => true]);
     }
 
-    private function nurseType(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return mixed
+     */
+    private function nurseType(BursaryPeriod $bP): mixed {
         $elPot = ElPotential::where('bursary_period_id', $bP->id)
             ->select('el_potentials.id', 'sfas_programs.nurse_type')
             ->join('sfas_programs', 'sfas_programs.sfas_program_code', 'el_potentials.program_code')
@@ -567,8 +638,12 @@ class NebController extends Controller
         return $elPot;
     }
 
-    private function eligibility(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return mixed
+     */
+    private function eligibility(BursaryPeriod $bP): mixed {
         $elPot = ElPotential::where('bursary_period_id', $bP->id)->get();
 
         foreach ($elPot as $item) {
@@ -602,8 +677,12 @@ class NebController extends Controller
         return $elPot;
     }
 
-    private function rank(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    private function rank(BursaryPeriod $bP): true {
         // RankByUnmetNeed
         $elPot = ElPotential::where('bursary_period_id', $bP->id)
             ->where('eligibility', 'Eligible')->orderBy('weekly_unmet_need', 'desc')->get();
@@ -659,8 +738,12 @@ class NebController extends Controller
         return true;
     }
 
-    private function awardOrDeny(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    private function awardOrDeny(BursaryPeriod $bP): true {
         $defaultAward = $bP->default_award ?? 0;
         $periodBudget = $bP->period_budget ?? 0;
         $rNPortion = $bP->rn_budget ?? 0;
@@ -711,16 +794,24 @@ class NebController extends Controller
         return true;
     }
 
-    public function awardAmount(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return true
+     */
+    public function awardAmount(BursaryPeriod $bP): true {
         ElPotential::where('bursary_period_id', $bP->id)->where('award_or_deny', 'Award')
             ->update(['award_amount' => $bP->default_award]);
 
         return true;
     }
 
-    public function sfasAwardId(BursaryPeriod $bP)
-    {
+    /**
+     * @param \Modules\Neb\Entities\BursaryPeriod $bP
+     *
+     * @return \Modules\Neb\Entities\Neb|null
+     */
+    public function sfasAwardId(BursaryPeriod $bP): ?Neb {
         $strSQL = Neb::whereNotNull('sfas_award_id')
             ->select('sfas_award_id')
             ->orderBy('sfas_award_id', 'desc')
@@ -745,8 +836,13 @@ class NebController extends Controller
         return null;
     }
 
-    public function awardedTextLine($record, $bp)
-    {
+    /**
+     * @param $record
+     * @param $bp
+     *
+     * @return string
+     */
+    public function awardedTextLine($record, $bp): string {
         $line = 'SP04';
         $line .= $this->padStringWithSpaces(date('Ymd', strtotime($bp->bursary_period_start_date)), 8);
         $line .= $this->padStringWithSpaces(date('Ymd', strtotime($bp->bursary_period_end_date)), 8);
@@ -786,8 +882,12 @@ class NebController extends Controller
         return $line;
     }
 
-    private function prepareCsvLine($record)
-    {
+    /**
+     * @param $record
+     *
+     * @return string
+     */
+    private function prepareCsvLine($record): string {
         $csvValues = [
             $record->application_number,
             $record->sin,
@@ -838,8 +938,14 @@ class NebController extends Controller
         return implode(',', $csvValues);
     }
 
-    private function padStringWithSpaces($inputString, $desiredLength, $preFixWithZero = false)
-    {
+    /**
+     * @param $inputString
+     * @param $desiredLength
+     * @param $preFixWithZero
+     *
+     * @return string
+     */
+    private function padStringWithSpaces($inputString, $desiredLength, $preFixWithZero = false): string {
         if ($inputString === null) {
             $inputString = '';
         }

--- a/Modules/Neb/Http/Controllers/ProgramController.php
+++ b/Modules/Neb/Http/Controllers/ProgramController.php
@@ -2,22 +2,23 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
+use Inertia\Response;
 use Modules\Neb\Entities\Program;
 use Modules\Neb\Http\Requests\ProgramStoreRequest;
-use Response;
 
 class ProgramController extends Controller
 {
+
     /**
      * Display a listing of the resource.
      *
      * @return \Inertia\Response
      */
-    public function index()
-    {
+    public function index(): Response {
         return Inertia::render('Neb::NebPrograms', ['page' => 'programs']);
     }
 
@@ -26,8 +27,7 @@ class ProgramController extends Controller
      *
      * @return response.json
      */
-    public function fetch(Request $request)
-    {
+    public function fetch(Request $request): Response {
         if ($request->id) {
             $program = Program::find($request->id);
 
@@ -49,10 +49,11 @@ class ProgramController extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param \Modules\Neb\Http\Requests\ProgramStoreRequest $request
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(ProgramStoreRequest $request)
-    {
+    public function store(ProgramStoreRequest $request): RedirectResponse {
         $program = Program::create($request->validated());
 
         return Redirect::route('neb.programs.show', [$program->id]);

--- a/Modules/Neb/Http/Controllers/ProgramController.php
+++ b/Modules/Neb/Http/Controllers/ProgramController.php
@@ -33,7 +33,7 @@ class ProgramController extends Controller
         if ($request->id) {
             $program = Program::find($request->id);
 
-            return Response::json([
+            return FacadeResponse::json([
                 'id' => $request->id,
                 'page' => 'programs',
                 'programs' => $program,

--- a/Modules/Neb/Http/Controllers/ProgramController.php
+++ b/Modules/Neb/Http/Controllers/ProgramController.php
@@ -2,11 +2,13 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Response as FacadeResponse;
 use Modules\Neb\Entities\Program;
 use Modules\Neb\Http\Requests\ProgramStoreRequest;
 
@@ -25,9 +27,9 @@ class ProgramController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return response.json
+     * @return \Illuminate\Http\JsonResponse.json
      */
-    public function fetch(Request $request): Response {
+    public function fetch(Request $request): JsonResponse {
         if ($request->id) {
             $program = Program::find($request->id);
 
@@ -40,7 +42,7 @@ class ProgramController extends Controller
 
         $nebPrograms = Program::orderBy('program_code', 'asc')->get();
 
-        return Response::json([
+        return FacadeResponse::json([
             'page' => 'programs',
             'programs' => $nebPrograms,
         ]);

--- a/Modules/Neb/Http/Controllers/RestrictionController.php
+++ b/Modules/Neb/Http/Controllers/RestrictionController.php
@@ -2,11 +2,13 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
+use Inertia\Response;
 use Modules\Neb\Entities\Restriction;
 use Modules\Neb\Http\Requests\RestrictionStoreRequest;
-use Response;
+
 
 class RestrictionController extends Controller
 {
@@ -15,8 +17,7 @@ class RestrictionController extends Controller
      *
      * @return \Inertia\Response
      */
-    public function index()
-    {
+    public function index(): Response {
         return Inertia::render('Neb::Restrictions', ['page' => 'restrictions']);
     }
 
@@ -25,8 +26,7 @@ class RestrictionController extends Controller
      *
      * @return response.json
      */
-    public function fetch(\Illuminate\Http\Request $request)
-    {
+    public function fetch(\Illuminate\Http\Request $request): Response {
         if ($request->id) {
             $restriction = Restriction::find($request->id);
 
@@ -47,10 +47,11 @@ class RestrictionController extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param \Modules\Neb\Http\Requests\RestrictionStoreRequest $request
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(RestrictionStoreRequest $request)
-    {
+    public function store(RestrictionStoreRequest $request): RedirectResponse {
         $restriction = Restriction::create($request->validated());
 
         return Redirect::route('neb.restrictions.show', [$restriction->id]);

--- a/Modules/Neb/Http/Controllers/RestrictionController.php
+++ b/Modules/Neb/Http/Controllers/RestrictionController.php
@@ -2,10 +2,12 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Response as FacadeResponse;
 use Modules\Neb\Entities\Restriction;
 use Modules\Neb\Http\Requests\RestrictionStoreRequest;
 
@@ -24,13 +26,13 @@ class RestrictionController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return response.json
+     * @return \Illuminate\Http\JsonResponse.json
      */
-    public function fetch(\Illuminate\Http\Request $request): Response {
+    public function fetch(\Illuminate\Http\Request $request): JsonResponse {
         if ($request->id) {
             $restriction = Restriction::find($request->id);
 
-            return Response::json([
+            return FacadeResponse::json([
                 'page' => 'restrictions',
                 'restrictions' => $restriction,
             ]);
@@ -38,7 +40,7 @@ class RestrictionController extends Controller
 
         $restrictions = Restriction::orderBy('restriction_code', 'asc')->get();
 
-        return Response::json([
+        return FacadeResponse::json([
             'page' => 'restrictions',
             'restrictions' => $restrictions,
         ]);

--- a/Modules/Neb/Http/Controllers/SfasProgramController.php
+++ b/Modules/Neb/Http/Controllers/SfasProgramController.php
@@ -2,12 +2,13 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
+use Inertia\Response;
 use Modules\Neb\Entities\Program;
 use Modules\Neb\Entities\SfasProgram;
 use Modules\Neb\Http\Requests\SfasProgramStoreRequest;
-use Response;
 
 class SfasProgramController extends Controller
 {
@@ -16,8 +17,7 @@ class SfasProgramController extends Controller
      *
      * @return \Inertia\Response
      */
-    public function index()
-    {
+    public function index(): Response {
         return Inertia::render('Neb::SfasPrograms', ['page' => 'sfas-programs']);
     }
 
@@ -26,8 +26,7 @@ class SfasProgramController extends Controller
      *
      * @return response.json
      */
-    public function fetch(\Illuminate\Http\Request $request)
-    {
+    public function fetch(\Illuminate\Http\Request $request): Response {
         if ($request->id) {
             $sfasProgram = SfasProgram::find($request->id);
 
@@ -50,10 +49,11 @@ class SfasProgramController extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param \Modules\Neb\Http\Requests\SfasProgramStoreRequest $request
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function store(SfasProgramStoreRequest $request)
-    {
+    public function store(SfasProgramStoreRequest $request): RedirectResponse {
         $sfasProgram = SfasProgram::create($request->validated());
 
         return Redirect::route('neb.sfas-programs.show', [$sfasProgram->id]);

--- a/Modules/Neb/Http/Controllers/SfasProgramController.php
+++ b/Modules/Neb/Http/Controllers/SfasProgramController.php
@@ -2,10 +2,12 @@
 
 namespace Modules\Neb\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Response as FacadeResponse;
 use Modules\Neb\Entities\Program;
 use Modules\Neb\Entities\SfasProgram;
 use Modules\Neb\Http\Requests\SfasProgramStoreRequest;
@@ -24,13 +26,13 @@ class SfasProgramController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return response.json
+     * @return \Illuminate\Http\JsonResponse
      */
-    public function fetch(\Illuminate\Http\Request $request): Response {
+    public function fetch(\Illuminate\Http\Request $request): JsonResponse {
         if ($request->id) {
             $sfasProgram = SfasProgram::find($request->id);
 
-            return Response::json([
+            return FacadeResponse::json([
                 'page' => 'sfas-programs',
                 'sfas_programs' => $sfasProgram,
             ]);
@@ -39,7 +41,7 @@ class SfasProgramController extends Controller
         $sfasPrograms = SfasProgram::orderBy('sfas_program_code', 'asc')->get();
         $programs = Program::orderBy('program_code', 'asc')->get();
 
-        return Response::json([
+        return FacadeResponse::json([
             'page' => 'sfas-programs',
             'sfas_programs' => $sfasPrograms,
             'programs' => $programs,

--- a/Modules/Neb/Http/Requests/BursaryPeriodEditRequest.php
+++ b/Modules/Neb/Http/Requests/BursaryPeriodEditRequest.php
@@ -11,18 +11,16 @@ class BursaryPeriodEditRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class BursaryPeriodEditRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'bursary_period_start_date' => 'required|unique:'.env('DB_DATABASE_NEB').'.bursary_periods,bursary_period_start_date,'.$this->id,
             'bursary_period_end_date' => 'required|unique:'.env('DB_DATABASE_NEB').'.bursary_periods,bursary_period_end_date,'.$this->id,
@@ -50,8 +47,7 @@ class BursaryPeriodEditRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
         if (isset($this->application_status) && $this->application_status != 'DENIED') {
             $this->merge(['denial_reason' => null]);
         }

--- a/Modules/Neb/Http/Requests/BursaryPeriodStoreRequest.php
+++ b/Modules/Neb/Http/Requests/BursaryPeriodStoreRequest.php
@@ -11,18 +11,16 @@ class BursaryPeriodStoreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class BursaryPeriodStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'bursary_period_start_date' => 'required|unique:'.env('DB_DATABASE_NEB').'.bursary_periods,bursary_period_start_date',
             'bursary_period_end_date' => 'required|unique:'.env('DB_DATABASE_NEB').'.bursary_periods,bursary_period_end_date',
@@ -49,7 +46,6 @@ class BursaryPeriodStoreRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
     }
 }

--- a/Modules/Neb/Http/Requests/NebStoreRequest.php
+++ b/Modules/Neb/Http/Requests/NebStoreRequest.php
@@ -11,18 +11,16 @@ class NebStoreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class NebStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'sfas_program_code' => 'required|unique:'.env('DB_DATABASE_NEB').'.sfas_programs,sfas_program_code|max:4',
             'area_of_study' => 'required|min:3',
@@ -49,7 +46,6 @@ class NebStoreRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
     }
 }

--- a/Modules/Neb/Http/Requests/ProgramStoreRequest.php
+++ b/Modules/Neb/Http/Requests/ProgramStoreRequest.php
@@ -11,18 +11,16 @@ class ProgramStoreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class ProgramStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'program_code' => 'required|unique:'.env('DB_DATABASE_NEB').'.programs,program_code|max:4',
             'program_description' => 'required|min:3',
@@ -45,7 +42,6 @@ class ProgramStoreRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
     }
 }

--- a/Modules/Neb/Http/Requests/RestrictionStoreRequest.php
+++ b/Modules/Neb/Http/Requests/RestrictionStoreRequest.php
@@ -11,18 +11,16 @@ class RestrictionStoreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class RestrictionStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'restriction_code' => 'required|unique:'.env('DB_DATABASE_NEB').'.restrictions,restriction_code|max:4',
             'restriction_description' => 'required|min:3',
@@ -45,7 +42,6 @@ class RestrictionStoreRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
     }
 }

--- a/Modules/Neb/Http/Requests/SfasProgramStoreRequest.php
+++ b/Modules/Neb/Http/Requests/SfasProgramStoreRequest.php
@@ -11,18 +11,16 @@ class SfasProgramStoreRequest extends FormRequest
      *
      * @return bool
      */
-    public function authorize()
-    {
+    public function authorize(): bool {
         return true;
     }
 
     /**
      * Get the error messages for the defined validation rules.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function messages()
-    {
+    public function messages(): array {
         return [
         ];
     }
@@ -30,10 +28,9 @@ class SfasProgramStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array
+     * @return array<string, string>
      */
-    public function rules()
-    {
+    public function rules(): array {
         return [
             'sfas_program_code' => 'required|unique:'.env('DB_DATABASE_NEB').'.sfas_programs,sfas_program_code|max:4',
             'area_of_study' => 'required|min:3',
@@ -49,7 +46,6 @@ class SfasProgramStoreRequest extends FormRequest
      *
      * @return void
      */
-    protected function prepareForValidation()
-    {
+    protected function prepareForValidation(): void {
     }
 }

--- a/Modules/Neb/Providers/NebServiceProvider.php
+++ b/Modules/Neb/Providers/NebServiceProvider.php
@@ -21,8 +21,7 @@ class NebServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
-    {
+    public function boot(): void {
         $this->registerTranslations();
         $this->registerConfig();
         $this->registerViews();
@@ -34,8 +33,7 @@ class NebServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
-    {
+    public function register(): void {
         $this->app->register(RouteServiceProvider::class);
     }
 
@@ -44,8 +42,7 @@ class NebServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerConfig()
-    {
+    protected function registerConfig(): void {
         $this->publishes([
             module_path($this->moduleName, 'Config/config.php') => config_path($this->moduleNameLower.'.php'),
         ], 'config');
@@ -59,8 +56,7 @@ class NebServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function registerViews()
-    {
+    public function registerViews(): void {
         $viewPath = resource_path('views/modules/'.$this->moduleNameLower);
 
         $sourcePath = module_path($this->moduleName, 'Resources/views');
@@ -77,8 +73,7 @@ class NebServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function registerTranslations()
-    {
+    public function registerTranslations(): void {
         $langPath = resource_path('lang/modules/'.$this->moduleNameLower);
 
         if (is_dir($langPath)) {
@@ -91,13 +86,15 @@ class NebServiceProvider extends ServiceProvider
     /**
      * Get the services provided by the provider.
      *
-     * @return array
+     * @return array<string>
      */
-    public function provides()
-    {
+    public function provides(): array {
         return [];
     }
 
+    /**
+     * @return array<string>
+     */
     private function getPublishableViewPaths(): array
     {
         $paths = [];

--- a/Modules/Neb/Providers/RouteServiceProvider.php
+++ b/Modules/Neb/Providers/RouteServiceProvider.php
@@ -21,8 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
-    {
+    public function boot(): void {
         parent::boot();
     }
 
@@ -31,8 +30,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function map()
-    {
+    public function map(): void {
         $this->mapApiRoutes();
 
         $this->mapWebRoutes();
@@ -45,8 +43,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function mapWebRoutes()
-    {
+    protected function mapWebRoutes(): void {
         Route::middleware('web')
             ->namespace($this->moduleNamespace)
             ->group(module_path('Neb', '/Routes/web.php'));
@@ -59,8 +56,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function mapApiRoutes()
-    {
+    protected function mapApiRoutes(): void {
         Route::prefix('api')
             ->middleware('api')
             ->namespace($this->moduleNamespace)


### PR DESCRIPTION
- Added return types to all methods
- Fixed issues with calls to undefined properties (added annotation)
- Added missing types to method attributes
- Updated PHPDoc
- Fixed issues with wrong attributes types
- Fixed warning messages with missing attributes annotations
- Fixed issues with Seeders (wrong fakers methods used)
- substr((string)($currentYear + $i + 1), -2); >> Fixed warning message: making sure the value used by substr is a string