### PR TITLE
Fixed various issues detected by Copilot

### DIFF
--- a/Modules/Vss/Resources/assets/js/Pages/Dashboard.vue
+++ b/Modules/Vss/Resources/assets/js/Pages/Dashboard.vue
@@ -81,9 +81,6 @@ export default {
     props: {
         results: Object,
     },
-    data() {
-        return {};
-    },
     methods: {
     },
     watch: {

--- a/Modules/Yeaf/Http/Controllers/GrantController.php
+++ b/Modules/Yeaf/Http/Controllers/GrantController.php
@@ -196,7 +196,7 @@ class GrantController extends Controller
 
         $overall_app_ineligible = false;
         $overall_messages = [];
-        [$msg, $app_ineligible, $appeal_status, $age] = $this->checkAge(true,  $grant);
+        [$msg, $app_ineligible, $appeal_status, $age] = $this->checkAge(true, $grant);
         $grant->age = $age;
         $grant->save();
         $grant = Grant::find($grant->id);
@@ -286,7 +286,7 @@ class GrantController extends Controller
 
     }
 
-    private function updateDeniedIneligibles(Grant $grant, GrantEditRequest $request): null {
+    private function updateDeniedIneligibles(Grant $grant, GrantEditRequest $request): void {
         //update existing records
         if (isset($request->grant_denied_ineligibles)) {
             foreach ($request->grant_denied_ineligibles as $denied) {
@@ -316,10 +316,9 @@ class GrantController extends Controller
             }
         }
 
-        return null;
     }
 
-    private function updateAppeals(Grant $grant, GrantEditRequest $request): null {
+    private function updateAppeals(Grant $grant, GrantEditRequest $request): void {
         //update existing records
         if (isset($request->appeals)) {
             foreach ($request->input('appeals') as $appeal) {
@@ -357,7 +356,6 @@ class GrantController extends Controller
             }
         }
 
-        return null;
     }
 
     private function setStatus(Grant $grant): string {

--- a/Modules/Yeaf/Policies/IneligiblePolicy.php
+++ b/Modules/Yeaf/Policies/IneligiblePolicy.php
@@ -11,7 +11,7 @@ class IneligiblePolicy
 {
     use HandlesAuthorization;
 
-    public function before(User $user): bool {
+    public function before(User $user, $ability): bool {
         return $user->hasRole(Role::SUPER_ADMIN) || $user->hasRole(Role::YEAF_ADMIN);
     }
 


### PR DESCRIPTION
- Policy method 'view' should return bool to indicate authorization status, not void. Laravel policies require boolean return values to function properly.
- The 'before' method is missing the required '$ability' parameter. Laravel policy 'before' methods should have signature: before(User $user, $ability)
- There are extra spaces in the method call parameter list. Should be 'checkAge(true, $grant)' with proper spacing.
- Empty data function returning an empty object is unnecessary. Consider removing the data() method entirely if no reactive data is needed.