### PR TITLE
- Inconsistent string comparison style. Use !== '' for strict compari…

### DIFF
--- a/Modules/Yeaf/Http/Controllers/GrantController.php
+++ b/Modules/Yeaf/Http/Controllers/GrantController.php
@@ -215,7 +215,7 @@ class GrantController extends Controller
 
         $grant = Grant::find($grant->id);
         $msg = $this->setStatus($grant);
-        if ($msg != '') {
+        if ($msg !== '') {
             $overall_messages[] = $msg;
         }
         $grant = Grant::find($grant->id);

--- a/Modules/Yeaf/Policies/BatchPolicy.php
+++ b/Modules/Yeaf/Policies/BatchPolicy.php
@@ -11,7 +11,7 @@ class BatchPolicy
 {
     use HandlesAuthorization;
 
-    public function before(User $user): bool {
+    public function before(User $user, string $ability): bool {
         return $user->hasRole(Role::SUPER_ADMIN) || $user->hasRole(Role::YEAF_ADMIN);
     }
 


### PR DESCRIPTION
…son to match the pattern used in line 243.

- The before method signature is incorrect - it should accept (User $user, string $ability) parameters according to Laravel's policy contract.