### PR TITLE
Dev

### DIFF
--- a/app/Http/Middleware/ApiAuth.php
+++ b/app/Http/Middleware/ApiAuth.php
@@ -27,12 +27,12 @@ class ApiAuth
 
         // Prevent access to the API except via the gateway
         if ($forwardedHost !== env('KEYCLOAK_APS_URL')) {
-            return Response::json(['error' => 'Unauthorized'], 403);
+            return response()->json(['error' => 'Unauthorized'], 403);
         }
 
         $token = request()->bearerToken();
         if(is_null($token)){
-            return Response::json(['status' => false, 'error' => 'Missing token.'], 401);
+            return response()->json(['status' => false, 'error' => 'Missing token.'], 401);
         }
         $jwksUri = env('KEYCLOAK_APS_ISS') . env('KEYCLOAK_APS_CERT_PATH');
         $jwksJson = file_get_contents($jwksUri);
@@ -51,9 +51,9 @@ class ApiAuth
         try {
             $decoded = JWT::decode($token, new Key($pk, 'RS256'));
         } catch (ExpiredException) {
-            return Response::json(['status' => false, 'error' => 'Token has expired.'], 401);
+            return response()->json(['status' => false, 'error' => 'Token has expired.'], 401);
         } catch (Exception $e) {
-            return Response::json(['status' => false, 'error' => "An error occurred: " . $e->getMessage()], 401);
+            return response()->json(['status' => false, 'error' => "An error occurred: " . $e->getMessage()], 401);
         }
             //only validate for accounts that we have registered
         if (isset($decoded->iss) && $decoded->iss === env('KEYCLOAK_APS_ISS')) {
@@ -64,6 +64,6 @@ class ApiAuth
 //                }
         }
 
-        return Response::json(['status' => false, 'error' => "Generic error."], 403);
+        return response()->json(['status' => false, 'error' => "Generic error."], 403);
     }
 }

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
     protected $except = [
-        //
+        '/pdex-login',
     ];
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ Route::get('/', fn() => redirect('/login'));
 Route::get('/login', [UserController::class, 'login'])->name('login');
 Route::get('/applogin', [UserController::class, 'appLogin'])->name('app-login');
 Route::middleware(['auth'])->get('/home', [UserController::class, 'home'])->name('home');
+Route::post('/pdex-login', [UserController::class, 'pdexLogin'])->name('pdex-login');
 
 
 


### PR DESCRIPTION
This pull request introduces a new endpoint for PDEX login and improves JWT handling and error response consistency throughout the authentication flow. The main changes include adding a `pdexLogin` method for handling PDEX authentication, updating CSRF exemptions, and ensuring all API error responses use a consistent response format.

**PDEX Login Feature:**

* Added a new `pdexLogin` method to `UserController` for handling PDEX authentication. This includes JWT decoding, validation of required fields, user registration if needed, and appropriate login or error responses. Also added a helper method `decodeJWT` for JWT payload inspection.
* Registered a new POST route `/pdex-login` pointing to the new `pdexLogin` method.
* Exempted the `/pdex-login` route from CSRF protection to allow external authentication requests.

**API Error Handling Consistency:**

* Standardized all JSON error responses in `ApiAuth` middleware to use `response()->json()` instead of the `Response::json()` facade for consistency and clarity. [[1]](diffhunk://#diff-ea986283f038f83a3a75e906e9646c9065e53d27838d1fa172cb331d7be7010aL30-R35) [[2]](diffhunk://#diff-ea986283f038f83a3a75e906e9646c9065e53d27838d1fa172cb331d7be7010aL54-R56) [[3]](diffhunk://#diff-ea986283f038f83a3a75e906e9646c9065e53d27838d1fa172cb331d7be7010aL67-R67)