### PR TITLE
Issue 101

### DIFF
--- a/Modules/Lfp/Entities/Lfp.php
+++ b/Modules/Lfp/Entities/Lfp.php
@@ -67,8 +67,21 @@ class Lfp extends ModuleModel
     {
         if(empty($sin)) return null;
 
-        return DB::connection('oracle')
-            ->select(env("LFP_QUERY2") . "(" . implode(",", $sin) . ")");
+        //return DB::connection('oracle')
+        //    ->select(env("LFP_QUERY2") . "(" . implode(",", $sin) . ")");
+
+        $qry = env("LFP_QUERY2");
+        if (empty($qry)) {
+            return null;
+        }
+
+        try {
+            return DB::connection('oracle')
+                ->select($qry . "(" . implode(",", $sin) . ")");
+        } catch (\Exception $e) {
+            \Log::warning('Oracle connection failed for SFAS individual data: ' . $e->getMessage());
+            return null;
+        }
     }
 
     /**
@@ -80,8 +93,21 @@ class Lfp extends ModuleModel
     {
         if(empty($apps)) return null;
 
-        return DB::connection('oracle')
-            ->select(env("LFP_SFA_APPS") . "(" . implode(",", $apps) . ")");
+        //return DB::connection('oracle')
+        //    ->select(env("LFP_SFA_APPS") . "(" . implode(",", $apps) . ")");
+
+        $qry = env("LFP_SFA_APPS");
+        if (empty($qry)) {
+            return null;
+        }
+
+        try {
+            return DB::connection('oracle')
+                ->select($qry . "(" . implode(",", $apps) . ")");
+        } catch (\Exception $e) {
+            \Log::warning('Oracle connection failed for SFAS app data: ' . $e->getMessage());
+            return null;
+        }
     }
 
     /**

--- a/Modules/Lfp/Entities/Payment.php
+++ b/Modules/Lfp/Entities/Payment.php
@@ -52,6 +52,9 @@ class Payment extends ModuleModel
     {
         if(empty($payIds)) return null;
 
+        //return DB::connection('oracle')
+        //    ->select(env("LFP_SFA_PAY_TBL") . "(" . implode(",", $payIds) . ")");
+
         $qry = env("LFP_SFA_PAY_TBL");
         if (empty($qry)) {
             return null;

--- a/Modules/Lfp/Entities/Payment.php
+++ b/Modules/Lfp/Entities/Payment.php
@@ -24,6 +24,15 @@ class Payment extends ModuleModel
     protected $appends = ['sfas_payment_attr'];
 
     /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'both_eligibility_status' => 'boolean',
+    ];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>

--- a/Modules/Lfp/Entities/Payment.php
+++ b/Modules/Lfp/Entities/Payment.php
@@ -52,8 +52,18 @@ class Payment extends ModuleModel
     {
         if(empty($payIds)) return null;
 
-        return DB::connection('oracle')
-            ->select(env("LFP_SFA_PAY_TBL") . "(" . implode(",", $payIds) . ")");
+        $qry = env("LFP_SFA_PAY_TBL");
+        if (empty($qry)) {
+            return null;
+        }
+
+        try {
+            return DB::connection('oracle')
+                ->select($qry . "(" . implode(",", $payIds) . ")");
+        } catch (\Exception $e) {
+            \Log::warning('Oracle connection failed for SFAS payment data: ' . $e->getMessage());
+            return null;
+        }
     }
 
 
@@ -62,6 +72,16 @@ class Payment extends ModuleModel
      */
     public function getSfasPaymentAttrAttribute(): object|null
     {
-        return is_null($this->pay_idx) ? null : $this->sfasPayment([$this->pay_idx])[0];
+        //return is_null($this->pay_idx) ? null : $this->sfasPayment([$this->pay_idx])[0];
+        if (is_null($this->pay_idx)) {
+            return null;
+        }
+
+        $sfasPayments = $this->sfasPayment([$this->pay_idx]);
+        if (empty($sfasPayments)) {
+            return null;
+        }
+
+        return $sfasPayments[0];
     }
 }

--- a/Modules/Lfp/Http/Requests/PaymentEditRequest.php
+++ b/Modules/Lfp/Http/Requests/PaymentEditRequest.php
@@ -69,22 +69,11 @@ class PaymentEditRequest extends FormRequest
      *
      * @return void
      */
-    /*#[Override]
+    #[Override]
     protected function prepareForValidation(): void {
         // Convert both_eligibility_status to boolean
         if ($this->has('both_eligibility_status')) {
             $this->merge(['both_eligibility_status' => filter_var($this->both_eligibility_status, FILTER_VALIDATE_BOOLEAN)]);
         }
-    }*/
-    #[Override]
-    protected function prepareForValidation(): void {
-        $this->merge([
-            // Ensure the flag is always present as a boolean (default false when null/missing)
-            'both_eligibility_status' => filter_var(
-                $this->input('both_eligibility_status', false),
-                FILTER_VALIDATE_BOOLEAN
-            ),
-        ]);
     }
-    
 }

--- a/Modules/Lfp/Http/Requests/PaymentEditRequest.php
+++ b/Modules/Lfp/Http/Requests/PaymentEditRequest.php
@@ -69,11 +69,22 @@ class PaymentEditRequest extends FormRequest
      *
      * @return void
      */
-    #[Override]
+    /*#[Override]
     protected function prepareForValidation(): void {
         // Convert both_eligibility_status to boolean
         if ($this->has('both_eligibility_status')) {
             $this->merge(['both_eligibility_status' => filter_var($this->both_eligibility_status, FILTER_VALIDATE_BOOLEAN)]);
         }
+    }*/
+    #[Override]
+    protected function prepareForValidation(): void {
+        $this->merge([
+            // Ensure the flag is always present as a boolean (default false when null/missing)
+            'both_eligibility_status' => filter_var(
+                $this->input('both_eligibility_status', false),
+                FILTER_VALIDATE_BOOLEAN
+            ),
+        ]);
     }
+    
 }

--- a/Modules/Lfp/Resources/assets/js/Components/ApplicationEditFormTab.vue
+++ b/Modules/Lfp/Resources/assets/js/Components/ApplicationEditFormTab.vue
@@ -122,9 +122,9 @@ tr {
             </div>
             <div class="col-md-6">
                 <BreezeLabel for="selectBothEligibility" class="form-label" value="Both Eligibility Status" />
-                <BreezeSelect class="form-select" id="selectBothEligibility" v-model.number="editForm.both_eligibility_status">
-                    <option :value="0">No</option>
-                    <option :value="1">Yes</option>
+                <BreezeSelect class="form-select" id="selectBothEligibility" v-model="editForm.both_eligibility_status">
+                    <option :value="false">No</option>
+                    <option :value="true">Yes</option>
                 </BreezeSelect>
             </div>
 

--- a/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
+++ b/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
@@ -157,31 +157,31 @@
                                 <!--                                'sfas_pay_status' => 'nullable',
                                 'oc_pay_status' => 'nullable',-->
 
-                                <div class="col-md-3">
+                                <div class="col-md-6">
                                     <BreezeLabel for="selectCommunity" class="form-label" value="Community" />
                                     <BreezeSelect class="form-select" id="selectCommunity" v-model="editPaymentForm.community">
                                         <option v-for="u in utils['Community']" :value="u">{{ u }}</option>
                                     </BreezeSelect>
                                 </div>
-                                <div class="col-md-3">
+                                <div class="col-md-6">
                                     <BreezeLabel for="selectProfession" class="form-label" value="Profession" />
                                     <BreezeSelect class="form-select" id="selectProfession" v-model="editPaymentForm.profession">
                                         <option v-for="u in utils['Profession']" :value="u">{{ u }}</option>
                                     </BreezeSelect>
                                 </div>
-                                <div class="col-md-3">
+                                <div class="col-md-4">
                                     <BreezeLabel for="selectEmployer" class="form-label" value="Employer" />
                                     <BreezeSelect class="form-select" id="selectEmployer" v-model="editPaymentForm.employer">
                                         <option v-for="u in utils['Employer']" :value="u">{{ u }}</option>
                                     </BreezeSelect>
                                 </div>
-                                <div class="col-md-3">
+                                <div class="col-md-4">
                                     <BreezeLabel for="selectEmploymentStatus" class="form-label" value="Employment Status" />
                                     <BreezeSelect class="form-select" id="selectEmploymentStatus" v-model="editPaymentForm.employment_status">
                                         <option v-for="u in utils['Employment Status']" :value="u">{{ u }}</option>
                                     </BreezeSelect>
                                 </div>
-                                <div class="col-md-3">
+                                <div class="col-md-4">
                                     <BreezeLabel for="selectBothEligibility" class="form-label" value="Both Eligibility" />
                                     <BreezeSelect class="form-select" id="selectBothEligibility" v-model="editPaymentForm.both_eligibility_status">
                                         <option :value="false">No</option>

--- a/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
+++ b/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
@@ -247,8 +247,15 @@ export default {
         },
         updatePayment: function(i)
         {
-            this.editPaymentForm = useForm(this.payments[i]);
+            /*this.editPaymentForm = useForm(this.payments[i]);
             this.editPaymentForm.proposed_pay_amount = this.$formatAmount(this.editPaymentForm.proposed_pay_amount);
+            $("#editPaymentModal").modal('show');*/
+            const p = this.payments[i];
+            this.editPaymentForm = useForm({
+                ...p,
+                both_eligibility_status: p.both_eligibility_status ?? false, // ensure boolean is present
+            });
+            this.editPaymentForm.proposed_pay_amount = this.$formatAmount(this.editPaymentForm.proposed_pay_amount);    
             $("#editPaymentModal").modal('show');
         },
         editPayment: function ()

--- a/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
+++ b/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
@@ -183,9 +183,9 @@
                                 </div>
                                 <div class="col-md-3">
                                     <BreezeLabel for="selectBothEligibility" class="form-label" value="Both Eligibility" />
-                                    <BreezeSelect class="form-select" id="selectBothEligibility" v-model.number="editPaymentForm.both_eligibility_status">
-                                        <option :value="0">No</option>
-                                        <option :value="1">Yes</option>
+                                    <BreezeSelect class="form-select" id="selectBothEligibility" v-model="editPaymentForm.both_eligibility_status">
+                                        <option :value="false">No</option>
+                                        <option :value="true">Yes</option>
                                     </BreezeSelect>
                                 </div>
 

--- a/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
+++ b/Modules/Lfp/Resources/assets/js/Components/ApplicationEditPaymentsTab.vue
@@ -247,15 +247,8 @@ export default {
         },
         updatePayment: function(i)
         {
-            /*this.editPaymentForm = useForm(this.payments[i]);
+            this.editPaymentForm = useForm(this.payments[i]);
             this.editPaymentForm.proposed_pay_amount = this.$formatAmount(this.editPaymentForm.proposed_pay_amount);
-            $("#editPaymentModal").modal('show');*/
-            const p = this.payments[i];
-            this.editPaymentForm = useForm({
-                ...p,
-                both_eligibility_status: p.both_eligibility_status ?? false, // ensure boolean is present
-            });
-            this.editPaymentForm.proposed_pay_amount = this.$formatAmount(this.editPaymentForm.proposed_pay_amount);    
             $("#editPaymentModal").modal('show');
         },
         editPayment: function ()

--- a/Modules/Lfp/Resources/assets/js/Pages/IntakeEdit.vue
+++ b/Modules/Lfp/Resources/assets/js/Pages/IntakeEdit.vue
@@ -124,9 +124,9 @@
                                 </div>
                                 <div class="col-md-3">
                                     <BreezeLabel for="selectBothEligibility" class="form-label" value="Both Eligibility Status" />
-                                    <BreezeSelect class="form-select" id="selectBothEligibility" v-model.number="intakeForm.both_eligibility_status" :disabled="isFormDisabled">
-                                        <option :value="0">No</option>
-                                        <option :value="1">Yes</option>
+                                    <BreezeSelect class="form-select" id="selectBothEligibility" v-model="intakeForm.both_eligibility_status" :disabled="isFormDisabled">
+                                        <option :value="false">No</option>
+                                        <option :value="true">Yes</option>
                                     </BreezeSelect>
                                 </div>
 

--- a/Modules/Lfp/Resources/assets/js/Pages/IntakeNew.vue
+++ b/Modules/Lfp/Resources/assets/js/Pages/IntakeNew.vue
@@ -121,9 +121,9 @@
                                         </div>
                                         <div class="col-md-3">
                                             <BreezeLabel for="selectBothEligibility" class="form-label" value="Both Eligibility Status" />
-                                            <BreezeSelect class="form-select" id="selectBothEligibility" v-model.number="intakeForm.both_eligibility_status">
-                                                <option :value="0">No</option>
-                                                <option :value="1">Yes</option>
+                                            <BreezeSelect class="form-select" id="selectBothEligibility" v-model="intakeForm.both_eligibility_status">
+                                                <option :value="false">No</option>
+                                                <option :value="true">Yes</option>
                                             </BreezeSelect>
                                         </div>
 
@@ -197,7 +197,7 @@ export default {
                 proposed_registration_date: '',
                 comment: '',
                 intake_status: 'Pending',
-                both_eligibility_status: 0,
+                both_eligibility_status: false,
             }),
         }
     },


### PR DESCRIPTION
Revert the change that defaulted both_eligibility_status on payment edit (LFP: default both_eligibility_status on payment edit to avoid null saves), returning dev to the pre-default behavior.
Keeps the earlier fixes intact (payment eligibility persistence, modal layout, and SFAS lookup guards).
