### PR TITLE
Upgrade Laravel Modules from v8 to v13

### DIFF
--- a/Modules/Vss/Resources/assets/js/Components/MaintenanceSchools.vue
+++ b/Modules/Vss/Resources/assets/js/Components/MaintenanceSchools.vue
@@ -155,7 +155,7 @@
 
 </template>
 <script>
-import {Link, useForm} from '@inertiajs/vue3';
+import {Link, useForm, router} from '@inertiajs/vue3';
 import BreezeInput from '@/Components/Input.vue';
 import BreezeLabel from '@/Components/Label.vue';
 
@@ -234,7 +234,7 @@ export default {
 
                     $("#editSchoolModal").modal('hide');
 
-                    Inertia.reload();
+                    router.reload();
                 },
                 onFailure: () => {
                 },

--- a/Modules/Vss/Resources/assets/js/Pages/CaseComment.vue
+++ b/Modules/Vss/Resources/assets/js/Pages/CaseComment.vue
@@ -198,7 +198,7 @@ export default {
             setTimeout(function (){
                 vm.showSuccessMsg = false;
                 vm.noChanges = true;
-                Inertia.get('/vss/case-comment/' + vm.result.id, {preserveState: true});
+                router.get('/vss/case-comment/' + vm.result.id, {preserveState: true});
 
             }, 4000);
         },

--- a/Modules/Yeaf/composer.json
+++ b/Modules/Yeaf/composer.json
@@ -7,27 +7,6 @@
             "email": "kal.marsh@gov.bc.ca"
         }
     ],
-    "require": {
-        "php": "^8.1",
-        "barryvdh/laravel-dompdf": "^2.0",
-        "guzzlehttp/guzzle": "^7.2",
-        "inertiajs/inertia-laravel": "^0.6.8",
-        "laravel/framework": "^10.10",
-        "laravel/sanctum": "^3.2",
-        "laravel/tinker": "^2.8",
-        "stevenmaguire/oauth2-keycloak": "^5.0",
-        "tightenco/ziggy": "^1.0"
-    },
-    "require-dev": {
-        "fakerphp/faker": "^1.9.1",
-        "laravel/breeze": "^1.21",
-        "laravel/pint": "^1.0",
-        "laravel/sail": "^1.18",
-        "mockery/mockery": "^1.4.4",
-        "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^10.1",
-        "spatie/laravel-ignition": "^2.0"
-    },
     "extra": {
         "laravel": {
             "providers": [],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laravel/framework": "^13.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
-        "nwidart/laravel-modules": "^8.3",
+        "nwidart/laravel-modules": "^13.0",
         "stevenmaguire/oauth2-keycloak": "^6.1.0",
         "tightenco/ziggy": "^2.0",
         "yajra/laravel-oci8": "^13.0"
@@ -68,7 +68,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "wikimedia/composer-merge-plugin": true
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "autoload": {
         "psr-4": {
             "App\\": "app/",
-			"Modules\\": "Modules/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
         }
@@ -63,6 +62,11 @@
     "extra": {
         "laravel": {
             "dont-discover": []
+        },
+        "merge-plugin": {
+            "include": [
+                "Modules/*/composer.json"
+            ]
         }
     },
     "config": {

--- a/config/modules.php
+++ b/config/modules.php
@@ -41,12 +41,12 @@ return [
             'package' => 'package.json',
         ],
         'replacements' => [
-            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME'],
-            'routes/api' => ['LOWER_NAME'],
-            'webpack' => ['LOWER_NAME'],
-            'json' => ['LOWER_NAME', 'STUDLY_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
+            'routes/web' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'routes/api' => ['LOWER_NAME', 'STUDLY_NAME', 'PLURAL_LOWER_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'CONTROLLER_NAMESPACE'],
+            'vite' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],
+            'json' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME', 'MODULE_NAMESPACE', 'PROVIDER_NAMESPACE'],
             'views/index' => ['LOWER_NAME'],
-            'views/master' => ['LOWER_NAME', 'STUDLY_NAME'],
+            'views/master' => ['LOWER_NAME', 'STUDLY_NAME', 'KEBAB_NAME'],
             'scaffold/config' => ['STUDLY_NAME'],
             'composer' => [
                 'LOWER_NAME',
@@ -102,7 +102,7 @@ return [
         | app folder name
         | for example can change it to 'src' or 'App'
         */
-        'app_folder' => 'app/',
+        'app_folder' => '',
 
         /*
         |--------------------------------------------------------------------------

--- a/config/modules.php
+++ b/config/modules.php
@@ -1,50 +1,7 @@
 <?php
 
-use Nwidart\Modules\Commands\CommandMakeCommand;
-use Nwidart\Modules\Commands\ComponentClassMakeCommand;
-use Nwidart\Modules\Commands\ComponentViewMakeCommand;
-use Nwidart\Modules\Commands\ControllerMakeCommand;
-use Nwidart\Modules\Commands\DisableCommand;
-use Nwidart\Modules\Commands\DumpCommand;
-use Nwidart\Modules\Commands\EnableCommand;
-use Nwidart\Modules\Commands\EventMakeCommand;
-use Nwidart\Modules\Commands\JobMakeCommand;
-use Nwidart\Modules\Commands\ListenerMakeCommand;
-use Nwidart\Modules\Commands\MailMakeCommand;
-use Nwidart\Modules\Commands\MiddlewareMakeCommand;
-use Nwidart\Modules\Commands\NotificationMakeCommand;
-use Nwidart\Modules\Commands\ProviderMakeCommand;
-use Nwidart\Modules\Commands\RouteProviderMakeCommand;
-use Nwidart\Modules\Commands\InstallCommand;
-use Nwidart\Modules\Commands\ListCommand;
-use Nwidart\Modules\Commands\ModuleDeleteCommand;
-use Nwidart\Modules\Commands\ModuleMakeCommand;
-use Nwidart\Modules\Commands\FactoryMakeCommand;
-use Nwidart\Modules\Commands\PolicyMakeCommand;
-use Nwidart\Modules\Commands\RequestMakeCommand;
-use Nwidart\Modules\Commands\RuleMakeCommand;
-use Nwidart\Modules\Commands\MigrateCommand;
-use Nwidart\Modules\Commands\MigrateRefreshCommand;
-use Nwidart\Modules\Commands\MigrateResetCommand;
-use Nwidart\Modules\Commands\MigrateRollbackCommand;
-use Nwidart\Modules\Commands\MigrateStatusCommand;
-use Nwidart\Modules\Commands\MigrationMakeCommand;
-use Nwidart\Modules\Commands\ModelMakeCommand;
-use Nwidart\Modules\Commands\PublishCommand;
-use Nwidart\Modules\Commands\PublishConfigurationCommand;
-use Nwidart\Modules\Commands\PublishMigrationCommand;
-use Nwidart\Modules\Commands\PublishTranslationCommand;
-use Nwidart\Modules\Commands\SeedCommand;
-use Nwidart\Modules\Commands\SeedMakeCommand;
-use Nwidart\Modules\Commands\SetupCommand;
-use Nwidart\Modules\Commands\UnUseCommand;
-use Nwidart\Modules\Commands\UpdateCommand;
-use Nwidart\Modules\Commands\UseCommand;
-use Nwidart\Modules\Commands\ResourceMakeCommand;
-use Nwidart\Modules\Commands\TestMakeCommand;
-use Nwidart\Modules\Commands\LaravelModulesV6Migrator;
 use Nwidart\Modules\Activators\FileActivator;
-use Nwidart\Modules\Commands;
+use Nwidart\Modules\Providers\ConsoleServiceProvider;
 
 return [
 
@@ -184,53 +141,10 @@ return [
     | you can simply comment them out.
     |
     */
-    'commands' => [
-        CommandMakeCommand::class,
-        ComponentClassMakeCommand::class,
-        ComponentViewMakeCommand::class,
-        ControllerMakeCommand::class,
-        DisableCommand::class,
-        DumpCommand::class,
-        EnableCommand::class,
-        EventMakeCommand::class,
-        JobMakeCommand::class,
-        ListenerMakeCommand::class,
-        MailMakeCommand::class,
-        MiddlewareMakeCommand::class,
-        NotificationMakeCommand::class,
-        ProviderMakeCommand::class,
-        RouteProviderMakeCommand::class,
-        InstallCommand::class,
-        ListCommand::class,
-        ModuleDeleteCommand::class,
-        ModuleMakeCommand::class,
-        FactoryMakeCommand::class,
-        PolicyMakeCommand::class,
-        RequestMakeCommand::class,
-        RuleMakeCommand::class,
-        MigrateCommand::class,
-        MigrateRefreshCommand::class,
-        MigrateResetCommand::class,
-        MigrateRollbackCommand::class,
-        MigrateStatusCommand::class,
-        MigrationMakeCommand::class,
-        ModelMakeCommand::class,
-        PublishCommand::class,
-        PublishConfigurationCommand::class,
-        PublishMigrationCommand::class,
-        PublishTranslationCommand::class,
-        SeedCommand::class,
-        SeedMakeCommand::class,
-        SetupCommand::class,
-        UnUseCommand::class,
-        UpdateCommand::class,
-        UseCommand::class,
-        ResourceMakeCommand::class,
-        TestMakeCommand::class,
-        LaravelModulesV6Migrator::class,
-        ComponentClassMakeCommand::class,
-        ComponentViewMakeCommand::class,
-    ],
+    'commands' => ConsoleServiceProvider::defaultCommands()
+       ->merge([
+           // New commands go here
+       ])->toArray(),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/modules.php
+++ b/config/modules.php
@@ -37,7 +37,7 @@ return [
             'composer' => 'composer.json',
             'assets/js/app' => 'Resources/assets/js/app.js',
             'assets/sass/app' => 'Resources/assets/sass/app.scss',
-            'webpack' => 'webpack.mix.js',
+            'vite' => 'vite.config.js',
             'package' => 'package.json',
         ],
         'replacements' => [
@@ -93,6 +93,17 @@ return [
         */
 
         'migration' => base_path('database/migrations'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | The app path
+        |--------------------------------------------------------------------------
+        |
+        | app folder name
+        | for example can change it to 'src' or 'App'
+        */
+        'app_folder' => 'app/',
+
         /*
         |--------------------------------------------------------------------------
         | Generator path


### PR DESCRIPTION
#### Changes:
As discussed, we're keeping the existing modules in their original structure for now.
The changes below are required for the `laravel-modules` v13 upgrade:

- Bumped the `laravel-modules` package to v13
- Updated module command registration for v13 compatibility
- Cleaned up old autoload mapping
- Added and enabled the composer merge plugin
- Updated the Laravel module config
- Removed some redundant dependencies in the `Yeaf` module to fix a build failure
- Fixed the `Inertia is not defined` issue found during testing