### PR TITLE
Migrate RVS web deployment from DeploymentConfig to Deployment

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -102,7 +102,8 @@ deploy-web:
 	test -n "$(BUILD_NAMESPACE)"
 	@echo "+\n++ Deploying Web into $(NAMESPACE)\n+"
 	@oc -n $(NAMESPACE) process -f dc_latest.yaml --param-file=$(PARAM_FILE) | oc -n $(NAMESPACE) apply -f -
-	$(call rollout_and_wait,dc/$(HOST_PREFIX))
+	@oc -n $(NAMESPACE) rollout restart deployment/$(HOST_PREFIX)
+	$(call rollout_and_wait,deployment/$(HOST_PREFIX))
 	@echo "+\n++ FINISHED Deploying Web\n+"
 
 build-patroni:

--- a/openshift/dc_latest.yaml
+++ b/openshift/dc_latest.yaml
@@ -219,20 +219,20 @@ objects:
     kind: NetworkPolicy
     metadata:
       name: ${NAME}-allow-external
-      spec:
-        podSelector:
-          matchLabels:
-            deployment: ${NAME}
-        ingress:
-          - ports:
-            - protocol: TCP
-              port: 8080
-            - protocol: TCP
-              port: 80
-            - protocol: TCP
-              port: 443
-        policyTypes:
-          - Ingress
+    spec:
+      podSelector:
+        matchLabels:
+          deployment: ${NAME}
+      ingress:
+        - ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 80
+          - protocol: TCP
+            port: 443
+      policyTypes:
+        - Ingress
 parameters:
   - name: OC_USER_ID
     required: false

--- a/openshift/dc_latest.yaml
+++ b/openshift/dc_latest.yaml
@@ -14,42 +14,32 @@ objects:
           protocol: TCP
           targetPort: 8443
       selector:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       sessionAffinity: None
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+        deployment: ${NAME}
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
         app.kubernetes.io/part-of: ${LABEL_NAME}
 
     spec:
-      triggers:
-        - type: "ConfigChange"
-        - type: "ImageChange"
-          imageChangeParams:
-            automatic: true
-            from:
-              kind: "ImageStreamTag"
-              name: ${NAME}:${IMAGE_TAG}
-              namespace: ${BUILD_NAMESPACE}
-            containerNames:
-              - ${NAME}
       replicas: ${{MIN_REPLICAS}}
       revisionHistoryLimit: 5
       selector:
-        deploymentconfig: ${NAME}
+        matchLabels:
+          deployment: ${NAME}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
-            deploymentconfig: ${NAME}
+            deployment: ${NAME}
             deploy-branch: ${REPO_BRANCH}
           annotations:
             vault.hashicorp.com/agent-inject: 'true'
@@ -72,7 +62,7 @@ objects:
                 name: subpath-env
           containers:
             - image: >-
-                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}
+                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}:${IMAGE_TAG}
               volumeMounts:
                 - name: site-data-volume
                   mountPath: /var/site_data
@@ -162,7 +152,7 @@ objects:
 
                       echo "==========> Starting schedule run"
 
-                      oc -n ${NAMESPACE} get pods -l deploymentconfig=${NAME} -o name | xargs -I {} sh -c 'oc exec -i {} -- php artisan job:dispatch-midnight && oc exec -i {} -- php artisan queue:work --once --queue=midnight'
+                      oc -n ${NAMESPACE} get pods -l deployment=${NAME} -o name | xargs -I {} sh -c 'oc exec -i {} -- php artisan job:dispatch-midnight && oc exec -i {} -- php artisan queue:work --once --queue=midnight'
 
                       echo "==========> Finished schedule run"
 
@@ -188,7 +178,7 @@ objects:
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       annotations:
         haproxy.router.openshift.io/ip_whitelist: 142.22.0.0/12 142.32.0.0/12 142.35.0.0/12
   - apiVersion: autoscaling.k8s.io/v1
@@ -196,24 +186,24 @@ objects:
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
     spec:
       targetRef:
-        kind: DeploymentConfig
+        kind: Deployment
         name: ${NAME}
-        apiVersion: apps.openshift.io/v1
+        apiVersion: apps/v1
       updatePolicy:
         updateMode: "Off"
   - apiVersion: autoscaling/v1
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       name: ${NAME}
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        apiVersion: apps/v1
+        kind: Deployment
         name: ${NAME}
       minReplicas: ${{MIN_REPLICAS}}
       maxReplicas: ${{MAX_REPLICAS}}
@@ -232,7 +222,7 @@ objects:
       spec:
         podSelector:
           matchLabels:
-            deploymentconfig: ${NAME}
+            deployment: ${NAME}
         ingress:
           - ports:
             - protocol: TCP


### PR DESCRIPTION
#### Changes:

- Updated the configuration in `dc_latest.yaml` and `Makefile` to use the Deployment label
- Removed the DC ImageChange trigger and replaced it with `rollout restart` during deployment
- Moved NetworkPolicy spec fields to the correct level
