### PR TITLE
Migrate backup deployment from DC to Deployment

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -145,8 +145,14 @@ db-backup-deploy-postgresql:
 		-p DATABASE_SECRET_NAME=patroni-creds \
 		-p DATABASE_SECRET_USER_KEY_NAME=superuser-username \
 		-p DATABASE_SECRET_PASSWORD_KEY_NAME=superuser-password \
+		-p CPU_REQUEST=50m \
+		-p CPU_LIMIT=250m \
+		-p MEMORY_REQUEST=256Mi \
+		-p MEMORY_LIMIT=1Gi \
   	-p ENVIRONMENT_FRIENDLY_NAME='$(NAMESPACE) POSTGRESQL DB Backups' \
 		| oc -n $(NAMESPACE) apply -f -
+	@oc -n $(NAMESPACE) rollout restart deployment/$(BACKUP_POSTGRESQL_APP_NAME)
+	$(call rollout_and_wait,deployment/$(BACKUP_POSTGRESQL_APP_NAME))
 
 
 build-cronjob:

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -145,10 +145,6 @@ db-backup-deploy-postgresql:
 		-p DATABASE_SECRET_NAME=patroni-creds \
 		-p DATABASE_SECRET_USER_KEY_NAME=superuser-username \
 		-p DATABASE_SECRET_PASSWORD_KEY_NAME=superuser-password \
-		-p CPU_REQUEST=50m \
-		-p CPU_LIMIT=250m \
-		-p MEMORY_REQUEST=256Mi \
-		-p MEMORY_LIMIT=1Gi \
   	-p ENVIRONMENT_FRIENDLY_NAME='$(NAMESPACE) POSTGRESQL DB Backups' \
 		| oc -n $(NAMESPACE) apply -f -
 	@oc -n $(NAMESPACE) rollout restart deployment/$(BACKUP_POSTGRESQL_APP_NAME)

--- a/openshift/backup-deploy.yaml
+++ b/openshift/backup-deploy.yaml
@@ -94,8 +94,8 @@ objects:
       ftp-password: ${FTP_PASSWORD}
       ftp-url-host: ${FTP_URL_HOST}
 
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${BACKUP_POSTGRESQL_APP_NAME}
       labels:
@@ -107,20 +107,10 @@ objects:
     spec:
       strategy:
         type: Recreate
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${BACKUP_POSTGRESQL_APP_NAME}
-            from:
-              kind: ImageStreamTag
-              namespace: ${IMAGE_NAMESPACE}
-              name: ${SOURCE_IMAGE_NAME}:${TAG_NAME}
       replicas: 1
       selector:
-        name: ${BACKUP_POSTGRESQL_APP_NAME}
+        matchLabels:
+          name: ${BACKUP_POSTGRESQL_APP_NAME}
       template:
         metadata:
           name: ${BACKUP_POSTGRESQL_APP_NAME}
@@ -145,7 +135,8 @@ objects:
                     path: ${CONFIG_FILE_NAME}
           containers:
             - name: ${BACKUP_POSTGRESQL_APP_NAME}
-              image: ""
+              image: image-registry.openshift-image-registry.svc:5000/${IMAGE_NAMESPACE}/${SOURCE_IMAGE_NAME}:${TAG_NAME}
+              imagePullPolicy: Always
               ports: []
               env:
                 - name: BACKUP_STRATEGY
@@ -219,13 +210,6 @@ objects:
                 - name: ${BACKUP_POSTGRESQL_APP_NAME}-config-volume
                   mountPath: ${CONFIG_MOUNT_PATH}${CONFIG_FILE_NAME}
                   subPath: ${CONFIG_FILE_NAME}
-      resources:
-        limits:
-          cpu: '250m'
-          memory: 1Gi
-        requests:
-          cpu: '50m'
-          memory: '256Mi'
   - kind: ConfigMap
     apiVersion: v1
     metadata:


### PR DESCRIPTION
#### Changes:

- Updated the configuration in `backup-deploy.yaml` to use the Deployment label
- Removed the DC ImageChange trigger and replaced it with `rollout restart` during deployment
- Removed the DC-level resources field, which is not supported by Deployment